### PR TITLE
API reference links corrections

### DIFF
--- a/.github/workflows/cd_release.yml
+++ b/.github/workflows/cd_release.yml
@@ -33,6 +33,11 @@ on:
         required: false
         type: string
         default: ""
+      relative:
+        description: "Whether or not to use install the local Python package(s) as an editable."
+        required: false
+        type: boolean
+        default: false
       python_version:
         description: "The Python version to use for the workflow."
         required: false
@@ -115,9 +120,12 @@ jobs:
 
     - name: Install Python dependencies
       run: |
+        EDITABLE=
+        if [ "${{ inputs.relative }}" == "true" ]; then EDITABLE=-e ; fi
+
         python -m pip install -U pip
         pip install -U setuptools wheel build
-        pip install .${{ inputs.install_extras }}
+        pip install ${EDITABLE}.${{ inputs.install_extras }}
         pip install git+https://github.com/SINTEF/ci-cd.git@v1
 
     - name: Update changelog
@@ -261,9 +269,12 @@ jobs:
 
     - name: Install Python dependencies
       run: |
+        EDITABLE=
+        if [ "${{ inputs.relative }}" == "true" ]; then EDITABLE=-e ; fi
+
         python -m pip install -U pip
         pip install -U setuptools wheel
-        pip install .${{ inputs.doc_extras || inputs.install_extras }}
+        pip install ${EDITABLE}.${{ inputs.doc_extras || inputs.install_extras }}
 
     - name: Set up git user
       run: |

--- a/.github/workflows/ci_cd_updated_default_branch.yml
+++ b/.github/workflows/ci_cd_updated_default_branch.yml
@@ -58,6 +58,11 @@ on:
         required: false
         type: string
         default: ""
+      relative:
+        description: "Whether or not to use install the local Python package(s) as an editable."
+        required: false
+        type: boolean
+        default: false
       exclude_dirs:
         description: "A single or multi-line string of directories to exclude in the Python API reference documentation. Note, only directory names, not paths, may be included. Note, all folders and their contents with these names will be excluded. Defaults to `'__pycache__'`. Important: When a user value is set, the preset value is overwritten - hence `'__pycache__'` should be included in the user value if one wants to exclude these directories."
         required: false
@@ -138,9 +143,12 @@ jobs:
     - name: Install Python dependencies
       if: env.RELEASE_RUN == 'false'
       run: |
+        EDITABLE=
+        if [ "${{ inputs.relative }}" == "true" ]; then EDITABLE=-e ; fi
+
         python -m pip install --upgrade pip
         pip install -U setuptools wheel
-        pip install .${{ inputs.doc_extras }}
+        pip install ${EDITABLE}.${{ inputs.doc_extras }}
         pip install git+https://github.com/SINTEF/ci-cd.git@v1
 
     - name: Set up git user

--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -38,6 +38,11 @@ on:
         required: false
         type: string
         default: ""
+      relative:
+        description: "Whether or not to use install the local Python package(s) as an editable, _only_ when running the `build_docs` job."
+        required: false
+        type: boolean
+        default: false
       skip_pre-commit_hooks:
         description: "A comma-separated list of pre-commit hook IDs to skip when running `pre-commit` after updating hooks."
         required: false
@@ -218,7 +223,7 @@ jobs:
     - name: Install Python dependencies
       run: |
         python -m pip install -U pip
-        pip install -U setuptools wheel
+        pip install -U setuptools wheel build
         if [ -n "${{ inputs.build_libs }}" ]; then
           pip install ${{ inputs.build_libs }}
         fi
@@ -244,9 +249,12 @@ jobs:
 
     - name: Install Python dependencies
       run: |
+        EDITABLE=
+        if [ "${{ inputs.relative }}" == "true" ]; then EDITABLE=-e ; fi
+
         python -m pip install -U pip
         pip install -U setuptools wheel
-        pip install .${{ inputs.install_extras }}
+        pip install ${EDITABLE}.${{ inputs.install_extras }}
         pip install git+https://github.com/SINTEF/ci-cd.git@v1
 
     - name: Update API Reference

--- a/ci_cd/tasks.py
+++ b/ci_cd/tasks.py
@@ -465,6 +465,10 @@ def update_deps(  # pylint: disable=too-many-branches,too-many-locals,too-many-s
             "models or to ensure all class attributes are listed. This input option "
             "can be supplied multiple times."
         ),
+        "relative": (
+            "Whether or not to use relative Python import links in the API reference "
+            "markdown files."
+        ),
         "debug": "Whether or not to print debug statements.",
     },
     iterable=["unwanted_folder", "unwanted_file", "full_docs_folder"],
@@ -479,6 +483,7 @@ def create_api_reference_docs(  # pylint: disable=too-many-locals,too-many-branc
     unwanted_folder=None,
     unwanted_file=None,
     full_docs_folder=None,
+    relative=False,
     debug=False,
 ):
     """Create the Python API Reference in the documentation."""
@@ -492,6 +497,7 @@ def create_api_reference_docs(  # pylint: disable=too-many-locals,too-many-branc
         pre_commit: bool = pre_commit
         root_repo_path: str = root_repo_path
         docs_folder: str = docs_folder
+        relative: bool = relative
         debug: bool = debug
 
     if not unwanted_folder:
@@ -602,15 +608,16 @@ def create_api_reference_docs(  # pylint: disable=too-many-locals,too-many-branc
                     )
                 continue
 
+            py_path_root = (
+                package_dir.relative_to(root_repo_path)
+                if relative
+                else package_dir.name
+            )
             basename = filename[: -len(".py")]
             py_path = (
-                f"{package_dir.relative_to(root_repo_path)}/{relpath}/{basename}".replace(
-                    "/", "."
-                )
+                f"{py_path_root}/{relpath}/{basename}".replace("/", ".")
                 if str(relpath) != "."
-                else f"{package_dir.relative_to(root_repo_path)}/{basename}".replace(
-                    "/", "."
-                )
+                else f"{py_path_root}/{basename}".replace("/", ".")
             )
             md_filename = filename.replace(".py", ".md")
             if debug:

--- a/docs/hooks/docs_api_reference.md
+++ b/docs/hooks/docs_api_reference.md
@@ -10,6 +10,24 @@ The hook will run when any Python file is changed in the repository.
 
 The hook expects the documentation to be setup with the [MkDocs](https://www.mkdocs.org) framework, including the [mkdocstrings](https://mkdocstrings.github.io/) plugin for parsing in the Python class/function and method doc-strings, as well as the [awesome-pages](https://github.com/lukasgeiter/mkdocs-awesome-pages-plugin) plugin for providing proper titles in the table-of-contents navigation.
 
+## Using it together with CI/CD workflows
+
+If this hook is being used together with the workflow [_CI - Tests_](../workflows/ci_tests.md#build-mkdocs-documentation), to test if the documentation can be built, or [_CD - Release_](../workflows/cd_release.md) and/or [_CI/CD - New updates to default branch_](../workflows/ci_cd_updated_default_branch.md), to build and publish the documentation upon a release or push to the default branch, it is necessary to understand the way the Python API modules are referenced in the markdown files under `docs/api_reference/`.
+
+By default, the references refer to the Python import path of a module.
+However, should a package be installed as an editable installation, i.e., using `pip install -e`, then the relative path from the repository root will be used.
+
+This differentiation is only relevant for repositories, where these two cases are not aligned, such as when the Python package folder is in a nested folder, e.g., `src/my_package/`.
+
+In order to remedy this, there are a single configuration in each workflow and this hooks that needs to be set to the same value.
+For this hook, the option name is `--relative` and the value for using the relative path, i.e., an editable installation, is to simply include this toggle option.
+If the option is _not_ included, then a non-editable installation is assumed, i.e., the `-e` option is _not_ used when installing the package, and a proper resolvable Python import statement is used as a link in the API reference markdown files.
+The latter is the default.
+
+For the workflows, one should set the configuration option `relative` to `true` to use the relative path, i.e., an editable installation.
+And likewise set `relative` to `false` if a proper resolvable Python import statement is to be used, without forcing the `-e` option.
+The latter is the default.
+
 ## Expectations
 
 It is **required** to specify the `--package-dir` argument through the `args` key.
@@ -27,6 +45,7 @@ Any of these options can be given through the `args` key when defining the hook.
 | `--unwanted-folder` | A folder to avoid including into the Python API reference documentation. If this is not supplied, it will default to `__pycache__`.</br></br>**Note**: Only folder names, not paths, may be included.</br></br>**Note**: All folders and their contents with these names will be excluded.</br></br>This input option can be supplied multiple times. | No | \_\_pycache\_\_ | _string_ |
 | `--unwanted-file` | A file to avoid including into the Python API reference documentation. If this is not supplied, it will default to `__init__.py`</br></br>**Note**: Only full file names, not paths, may be included, i.e., filename + file extension.</br></br>**Note**: All files with these names will be excluded.</br></br>This input option can be supplied multiple times. | No | \_\_init\_\_.py | _string_ |
 | `--full-docs-folder` | A folder in which to include everything - even those without documentation strings. This may be useful for a module full of data models or to ensure all class attributes are listed.</br></br>This input option can be supplied multiple times. | No | _Empty string_ | _string_ |
+| `--relative` | Whether or not to use relative Python import links in the API reference markdown files. See section [Using it together with CI/CD workflows](#using-it-together-with-cicd-workflows) above. | No | `False` | _boolean_ |
 | `--debug` | Whether or not to print debug statements. | No | `False` | _boolean_ |
 
 ## Usage example

--- a/docs/workflows/cd_release.md
+++ b/docs/workflows/cd_release.md
@@ -20,6 +20,9 @@ For more information about the specific changelog inputs, see the related [chang
 The `changelog_exclude_tags_regex` is also used to remove tags in a list of tags to consider when evaluating the "previous version".
 This is specifically for adding a changelog to the GitHub release body.
 
+If used together with the [Update API Reference in Documentation](../hooks/docs_api_reference.md#using-it-together-with-cicd-workflows), please align the `relative` input with the `--relative` option, when running the hook.
+See the [proper section](../hooks/docs_api_reference.md#using-it-together-with-cicd-workflows) to understand why and how these options and inputs should be aligned.
+
 ## Updating instances of version in repository files
 
 The content of repository files can be updated to use the new version where necessary.
@@ -66,6 +69,7 @@ The repository contains the following:
 | `package_dir` | Path to the Python package directory relative to the repository directory.</br></br>Example: `'src/my_package'`.</br></br>**Important**: This is _required_ if 'python_package' is 'true', which is the default. | **_Yes_ (if 'python_package' is 'true'** | | _string_ |
 | `release_branch` | The branch name to release/publish from. | No | main | _string_ |
 | `install_extras` | Any extras to install from the local repository through 'pip'. Must be encapsulated in square parentheses (`[]`) and be separated by commas (`,`) without any spaces.</br></br>Example: `'[dev,release]'`. | No | _Empty string_ | _string_ |
+| `relative` | Whether or not to use install the local Python package(s) as an editable. | No | `false` | _boolean_ |
 | `python_version` | The Python version to use for the workflow. | No | 3.9 | _string_ |
 | `version_update_changes` | A single or multi-line string of changes to be implemented in the repository files upon updating the version. The string should be made up of three parts: 'file path', 'pattern', and 'replacement string'. These are separated by the 'version_update_changes_separator' value.</br>The 'file path' must _always_ either be relative to the repository root directory or absolute.</br>The 'pattern' should be given as a 'raw' Python string. | No | _Empty string_ | _string_ |
 | `version_update_changes_separator` | The separator to use for 'version_update_changes' when splitting the three parts of each string. | No | , | _string_ |

--- a/docs/workflows/ci_cd_updated_default_branch.md
+++ b/docs/workflows/ci_cd_updated_default_branch.md
@@ -19,6 +19,9 @@ Furthermore, this workflow can optionally update the `latest` [mike](https://git
     The default value is given here as a help:  
     `'duplicate,question,invalid,wontfix'`
 
+If used together with the [Update API Reference in Documentation](../hooks/docs_api_reference.md#using-it-together-with-cicd-workflows), please align the `relative` input with the `--relative` option, when running the hook.
+See the [proper section](../hooks/docs_api_reference.md#using-it-together-with-cicd-workflows) to understand why and how these options and inputs should be aligned.
+
 ## Expectations
 
 The repository contains the following:
@@ -42,6 +45,7 @@ The repository contains the following:
 | `update_docs_landing_page` | Whether or not to update the documentation landing page. The landing page will be based on the root README.md file. | No | `true` | _boolean_ |
 | `python_version` | The Python version to use for the workflow.</br></br>**Note**: This is only relevant if `update_pre-commit` is `true`. | No | 3.9 | _string_ |
 | `doc_extras` | Any extras to install from the local repository through 'pip'. Must be encapsulated in square parentheses (`[]`) and be separated by commas (`,`) without any spaces.</br></br>Example: `'[docs]'`. | No | _Empty string_ | _string_ |
+| `relative` | Whether or not to use install the local Python package(s) as an editable. | No | `false` | _boolean_ |
 | `exclude_dirs` | A single or multi-line string of directories to exclude in the Python API reference documentation. Note, only directory names, not paths, may be included. Note, all folders and their contents with these names will be excluded. Defaults to `'__pycache__'`.</br></br>**Important**: When a user value is set, the preset value is overwritten - hence `'__pycache__'` should be included in the user value if one wants to exclude these directories. | No | \_\_pycache\_\_ | _string_ |
 | `exclude_files` | A single or multi-line string of files to exclude in the Python API reference documentation. Note, only full file names, not paths, may be included, i.e., filename + file extension. Note, all files with these names will be excluded. Defaults to `'__init__.py'`.</br></br>**Important**: When a user value is set, the preset value is overwritten - hence `'__init__.py'` should be included in the user value if one wants to exclude these files. | No | \_\_init\_\_.py | _string_ |
 | `full_docs_dirs` | A single or multi-line string of directories in which to include everything - even those without documentation strings. This may be useful for a module full of data models or to ensure all class attributes are listed. | No | _Empty string_ | _string_ |

--- a/docs/workflows/ci_tests.md
+++ b/docs/workflows/ci_tests.md
@@ -90,6 +90,9 @@ Test building the documentation within the [MkDocs](https://www.mkdocs.org) fram
 !!! note
     If using [mike](https://github.com/jimporter/mike), note that this will _not_ be tested, as this would be equivalent to testing mike itself and whether it can build a MkDocs documentation, which should never be part of a repository that uses these tools.
 
+If used together with the [Update API Reference in Documentation](../hooks/docs_api_reference.md#using-it-together-with-cicd-workflows), please align the `relative` input with the `--relative` option, when running the hook.
+See the [proper section](../hooks/docs_api_reference.md#using-it-together-with-cicd-workflows) to understand why and how these options and inputs should be aligned.
+
 #### Expectations
 
 Is is expected that documentation exists, which is using the MkDocs framework.
@@ -104,6 +107,7 @@ This requires at minimum a `mkdocs.yml` configuration file.
 | `update_docs_landing_page` | Whether or not to update the documentation landing page. The landing page will be based on the root README.md file. | No | `true` | _boolean_ |
 | `python_version` | The Python version to use for the workflow. | No | 3.9 | _string_ |
 | `install_extras` | Any extras to install from the local repository through 'pip'. Must be encapsulated in square parentheses (`[]`) and be separated by commas (`,`) without any spaces.</br></br>**Example**: `'[dev,docs]'`. | No | _Empty string_ | _string_ |
+| `relative` | Whether or not to use install the local Python package(s) as an editable. | No | `false` | _boolean_ |
 | `package_dir` | Path to the Python package directory relative to the repository directory.</br></br>**Example**: `'src/my_package'`. | **Yes, if `update_python_api_ref` is `true` (default)** | _Empty string_ | _string_ |
 | `exclude_dirs` | A single or multi-line string of directories to exclude in the Python API reference documentation. Note, only directory names, not paths, may be included. Note, all folders and their contents with these names will be excluded. Defaults to `'__pycache__'`.</br></br>**Important**: When a user value is set, the preset value is overwritten - hence `'__pycache__'` should be included in the user value if one wants to exclude these directories. | No | \_\_pycache\_\_ | _string_ |
 | `exclude_files` | A single or multi-line string of files to exclude in the Python API reference documentation. Note, only full file names, not paths, may be included, i.e., filename + file extension. Note, all files with these names will be excluded. Defaults to `'__init__.py'`.</br></br>**Important**: When a user value is set, the preset value is overwritten - hence `'__init__.py'` should be included in the user value if one wants to exclude these files. | No | \_\_init\_\_.py | _string_ |
@@ -193,6 +197,7 @@ However, it is recommended to instead refer to the job-specific tables of inputs
 | `update_docs_landing_page` | Whether or not to update the documentation landing page. The landing page will be based on the root README.md file. | No | `true` | _boolean_ |
 | `python_version` | The Python version to use for the workflow. | No | 3.9 | _string_ |
 | `install_extras` | Any extras to install from the local repository through 'pip'. Must be encapsulated in square parentheses (`[]`) and be separated by commas (`,`) without any spaces.</br></br>**Example**: `'[dev,docs]'`. | No | _Empty string_ | _string_ |
+| `relative` | Whether or not to use install the local Python package(s) as an editable, _only_ when running the `build_docs` job. | No | `false` | _boolean_ |
 | `package_dir` | Path to the Python package directory relative to the repository directory.</br></br>**Example**: `'src/my_package'`. | **Yes, if `update_python_api_ref` is `true` (default)** | _Empty string_ | _string_ |
 | `exclude_dirs` | A single or multi-line string of directories to exclude in the Python API reference documentation. Note, only directory names, not paths, may be included. Note, all folders and their contents with these names will be excluded. Defaults to `'__pycache__'`.</br></br>**Important**: When a user value is set, the preset value is overwritten - hence `'__pycache__'` should be included in the user value if one wants to exclude these directories. | No | \_\_pycache\_\_ | _string_ |
 | `exclude_files` | A single or multi-line string of files to exclude in the Python API reference documentation. Note, only full file names, not paths, may be included, i.e., filename + file extension. Note, all files with these names will be excluded. Defaults to `'__init__.py'`.</br></br>**Important**: When a user value is set, the preset value is overwritten - hence `'__init__.py'` should be included in the user value if one wants to exclude these files. | No | \_\_init\_\_.py | _string_ |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,5 +71,5 @@ allow_redefinition = true
 [tool.pylint.messages_control]
 max-line-length = 90
 disable = []
-max-args = 10
+max-args = 15
 max-branches = 15

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -79,6 +79,7 @@ def test_api_reference_nested_package() -> None:
             MockContext(),
             str(package_dir),
             root_repo_path=str(root_path),
+            relative=True,
         )
 
         api_reference_folder = docs_folder / "api_reference"


### PR DESCRIPTION
Fixes #46 

Introduces the `relative` input for relevant workflows as well as the `--relative` option for the `docs-api-reference` pre-commit hook.

The point of this input/option is to toggle whether or not to install the local Python package(s) as an editable installation (using the `-e` option for `pip install`) and creating the API reference markdown links into the Python API relative to the repository root or the importable Python package name.