### PR TITLE
Fix documentation typos

### DIFF
--- a/ci_cd/tasks.py
+++ b/ci_cd/tasks.py
@@ -710,9 +710,13 @@ def create_docs_index(  # pylint: disable=too-many-locals
         context: "Context" = context
         pre_commit: bool = pre_commit
         root_repo_path: str = root_repo_path
-        docs_folder: str = docs_folder
-        replacement: list[str] = replacement
         replacement_separator: str = replacement_separator
+
+    docs_folder: Path = Path(docs_folder)
+
+    if not replacement:
+        replacement: list[str] = []
+    replacement.append(f"{docs_folder.name}/{replacement_separator}")
 
     if pre_commit and root_repo_path == ".":
         # Use git to determine repo root

--- a/docs/workflows/cd_release.md
+++ b/docs/workflows/cd_release.md
@@ -1,4 +1,5 @@
 # CD - Release
+<!-- markdownlint-disable MD007 -->
 
 **File to use:** `cd_release.yml`
 
@@ -34,11 +35,12 @@ Some notes to consider and respect when using `version_update_changes` are:
 
 - The value of `version_update_changes_separator` applies to _all_ lines given in `version_update_changes`, meaning it should be a character, or series of characters, which will not be part of the actual content.
 - Specifically, concerning the 'raw' Python string 'pattern' the following applies:
-  - **Always** escape double quotes (`"`).
-    This is done by prefixing it with a backslash (`\`): `\"`.
-  - Escape special bash/sh characters, e.g., back tick (`` ` ``).
-  - Escape special Python regular expression characters, if they are not used for their intended purpose in this 'raw' string.
-    See the [`re` library documentation](https://docs.python.org/3/library/re.html) for more information.
+
+    - **Always** escape double quotes (`"`).
+      This is done by prefixing it with a backslash (`\`): `\"`.
+    - Escape special bash/sh characters, e.g., back tick (`` ` ``).
+    - Escape special Python regular expression characters, if they are not used for their intended purpose in this 'raw' string.
+      See the [`re` library documentation](https://docs.python.org/3/library/re.html) for more information.
 
 Concerning the 'replacement string' part, the `package_dirs` input and full semantic version can be substituted in dynamically by wrapping either `package_dir` or `version` in curly braces (`{}`).
 Indeed, for the version, one can specify sub-parts of the version to use, e.g., if one desires to only use the major version, this can be done by using the `major` attribute: `{version.major}`.

--- a/docs/workflows/ci_cd_updated_default_branch.md
+++ b/docs/workflows/ci_cd_updated_default_branch.md
@@ -79,7 +79,7 @@ jobs:
     name: Call external workflow
     uses: SINTEF/ci-cd/.github/workflows/ci_cd_updated_default_branch.yml@v1
     if: github.repository_owner == 'SINTEF'
-    inputs:
+    with:
       git_username: "Casper Welzel Andersen"
       git_email: "CasperWA@github.com"
       default_repo_branch: stable

--- a/docs/workflows/ci_check_pyproject_dependencies.md
+++ b/docs/workflows/ci_check_pyproject_dependencies.md
@@ -53,7 +53,7 @@ jobs:
     name: Call external workflow
     uses: SINTEF/ci-cd/.github/workflows/ci_check_pyproject_dependencies.yml@v1
     if: github.repository_owner == 'SINTEF'
-    inputs:
+    with:
       git_username: "Casper Welzel Andersen"
       git_email: "CasperWA@github.com"
       permanent_dependencies_branch: "ci/dependency-updates"

--- a/docs/workflows/ci_update_dependencies.md
+++ b/docs/workflows/ci_update_dependencies.md
@@ -64,7 +64,7 @@ jobs:
     name: Call external workflow
     uses: SINTEF/ci-cd/.github/workflows/ci_update_dependencies.yml@v1
     if: github.repository_owner == 'SINTEF'
-    inputs:
+    with:
       git_username: "Casper Welzel Andersen"
       git_email: "CasperWA@github.com"
       permanent_dependencies_branch: "ci/dependency-updates"


### PR DESCRIPTION
Fixes #52 

Fixes some typos in the documentation.

Fixes #53 

Implements the default removal of `{docs-folder}/` from the `README.md` during the `create-docs-index` task.