### PR TITLE
Changed to vMajor tag for pre-commit in ci_update_dependencies.yml

### DIFF
--- a/.github/utils/major_version_tag_msg.txt
+++ b/.github/utils/major_version_tag_msg.txt
@@ -1,3 +1,0 @@
-vMAJOR
-
-Tag pointing to the latest vMAJOR.x.y version.

--- a/.github/utils/update_tags.sh
+++ b/.github/utils/update_tags.sh
@@ -1,9 +1,0 @@
-#!/usr/bin/env bash
-set -e
-
-echo "### Move/update v<MAJOR> tag ###"
-MAJOR_VERSION=$( echo ${GITHUB_REF#refs/tags/v} | cut -d "." -f 1 )
-TAG_MSG=.github/utils/major_version_tag_msg.txt
-sed -i "s|MAJOR|${MAJOR_VERSION}|g" "${TAG_MSG}"
-
-git tag -af -F "${TAG_MSG}" v${MAJOR_VERSION}

--- a/.github/workflows/_local_cd_release.yml
+++ b/.github/workflows/_local_cd_release.yml
@@ -1,9 +1,10 @@
 name: CD - Release
 
 on:
-  release:
-    types:
-      - "published"
+  push:
+  #release:
+  #  types:
+  #    - "published"
 
 jobs:
   publish:
@@ -20,22 +21,22 @@ jobs:
       build_cmd: ".github/utils/update_tags.sh"
       update_docs: true
       doc_extras: "[docs]"
-      changelog_exclude_tags_regex: "^v[0-9]+$"
-      test: false
+      changelog_exclude_tags_regex: "^v[0-9]+.*$"
+      test: true # false
       version_update_changes_separator: ","
       version_update_changes: |
         {package_dir}/__init__.py,__version__ *= *(?:'|\").*(?:'|\"),__version__ = \"{version}\"
-        docs/index.md,^\*\*Current version to use:\*\* \`v[0-9]+\`$,**Current version to use:** \`v{version.major}\`
-        docs/hooks/docs_api_reference.md,rev: v[0-9]+$,rev: v{version.major}
-        docs/hooks/docs_landing_page.md,rev: v[0-9]+$,rev: v{version.major}
-        docs/workflows/cd_release.md,uses: SINTEF/ci-cd/\.github/workflows/cd_release\.yml@v[0-9]+$,uses: SINTEF/ci-cd/.github/workflows/cd_release.yml@v{version.major}
-        docs/workflows/ci_automerge_prs.md,uses: SINTEF/ci-cd/\.github/workflows/ci_automerge_prs\.yml@v[0-9]+$,uses: SINTEF/ci-cd/.github/workflows/ci_automerge_prs.yml@v{version.major}
-        docs/workflows/ci_cd_updated_default_branch.md,uses: SINTEF/ci-cd/\.github/workflows/ci_cd_updated_default_branch\.yml@v[0-9]+$,uses: SINTEF/ci-cd/.github/workflows/ci_cd_updated_default_branch.yml@v{version.major}
-        docs/workflows/ci_check_pyproject_dependencies.md,uses: SINTEF/ci-cd/\.github/workflows/ci_check_pyproject_dependencies\.yml@v[0-9]+$,uses: SINTEF/ci-cd/.github/workflows/ci_check_pyproject_dependencies.yml@v{version.major}
-        docs/workflows/ci_update_dependencies.md,uses: SINTEF/ci-cd/\.github/workflows/ci_update_dependencies\.yml@v[0-9]+$,uses: SINTEF/ci-cd/.github/workflows/ci_update_dependencies.yml@v{version.major}
-        .github/workflows/cd_release.yml,https://github\.com/SINTEF/ci-cd\.git@v[0-9]+$,https://github.com/SINTEF/ci-cd.git@v{version.major}
-        .github/workflows/ci_cd_updated_default_branch.yml,https://github\.com/SINTEF/ci-cd\.git@v[0-9]+$,https://github.com/SINTEF/ci-cd.git@v{version.major}
-        .github/workflows/ci_check_pyproject_dependencies.yml,https://github\.com/SINTEF/ci-cd\.git@v[0-9]+$,https://github.com/SINTEF/ci-cd.git@v{version.major}
-        docs/workflows/cd_release.md,\(https://github\.com/SINTEF/ci-cd/blob/v[0-9]+/\.github/workflows/_local_cd_release\.yml\),(https://github.com/SINTEF/ci-cd/blob/v{version.major}/.github/workflows/_local_cd_release.yml)
+        docs/index.md,^\*\*Current version to use:\*\* \`v[0-9]+.*\`$,**Current version to use:** \`v{version}\`
+        docs/hooks/docs_api_reference.md,rev: v[0-9]+.*$,rev: v{version}
+        docs/hooks/docs_landing_page.md,rev: v[0-9]+.*$,rev: v{version}
+        docs/workflows/cd_release.md,uses: SINTEF/ci-cd/\.github/workflows/cd_release\.yml@v[0-9]+.*$,uses: SINTEF/ci-cd/.github/workflows/cd_release.yml@v{version}
+        docs/workflows/ci_automerge_prs.md,uses: SINTEF/ci-cd/\.github/workflows/ci_automerge_prs\.yml@v[0-9]+.*$,uses: SINTEF/ci-cd/.github/workflows/ci_automerge_prs.yml@v{version}
+        docs/workflows/ci_cd_updated_default_branch.md,uses: SINTEF/ci-cd/\.github/workflows/ci_cd_updated_default_branch\.yml@v[0-9]+.*$,uses: SINTEF/ci-cd/.github/workflows/ci_cd_updated_default_branch.yml@v{version}
+        docs/workflows/ci_check_pyproject_dependencies.md,uses: SINTEF/ci-cd/\.github/workflows/ci_check_pyproject_dependencies\.yml@v[0-9]+.*$,uses: SINTEF/ci-cd/.github/workflows/ci_check_pyproject_dependencies.yml@v{version}
+        docs/workflows/ci_update_dependencies.md,uses: SINTEF/ci-cd/\.github/workflows/ci_update_dependencies\.yml@v[0-9]+.*$,uses: SINTEF/ci-cd/.github/workflows/ci_update_dependencies.yml@v{version}
+        .github/workflows/cd_release.yml,https://github\.com/SINTEF/ci-cd\.git@v[0-9]+.*$,https://github.com/SINTEF/ci-cd.git@v{version}
+        .github/workflows/ci_cd_updated_default_branch.yml,https://github\.com/SINTEF/ci-cd\.git@v[0-9]+.*$,https://github.com/SINTEF/ci-cd.git@v{version}
+        .github/workflows/ci_check_pyproject_dependencies.yml,https://github\.com/SINTEF/ci-cd\.git@v[0-9]+.*$,https://github.com/SINTEF/ci-cd.git@v{version}
+        docs/workflows/cd_release.md,\(https://github\.com/SINTEF/ci-cd/blob/v[0-9]+.*/\.github/workflows/_local_cd_release\.yml\),(https://github.com/SINTEF/ci-cd/blob/v{version}/.github/workflows/_local_cd_release.yml)
     secrets:
       PAT: ${{ secrets.RELEASE_PAT }}

--- a/.github/workflows/_local_cd_release.yml
+++ b/.github/workflows/_local_cd_release.yml
@@ -1,10 +1,9 @@
 name: CD - Release
 
 on:
-  push:
-  #release:
-  #  types:
-  #    - "published"
+  release:
+   types:
+     - "published"
 
 jobs:
   publish:
@@ -18,11 +17,10 @@ jobs:
       publish_on_pypi: false
       package_dirs: ci_cd
       release_branch: main
-      build_cmd: ".github/utils/update_tags.sh"
       update_docs: true
       doc_extras: "[docs]"
-      changelog_exclude_tags_regex: "^v[0-9]+.*$"
-      test: true # false
+      changelog_exclude_tags_regex: "^v[0-9]+$"  # Exclude 'v1' tag
+      test: false
       version_update_changes_separator: ","
       version_update_changes: |
         {package_dir}/__init__.py,__version__ *= *(?:'|\").*(?:'|\"),__version__ = \"{version}\"
@@ -34,9 +32,11 @@ jobs:
         docs/workflows/ci_cd_updated_default_branch.md,uses: SINTEF/ci-cd/\.github/workflows/ci_cd_updated_default_branch\.yml@v[0-9]+.*$,uses: SINTEF/ci-cd/.github/workflows/ci_cd_updated_default_branch.yml@v{version}
         docs/workflows/ci_check_pyproject_dependencies.md,uses: SINTEF/ci-cd/\.github/workflows/ci_check_pyproject_dependencies\.yml@v[0-9]+.*$,uses: SINTEF/ci-cd/.github/workflows/ci_check_pyproject_dependencies.yml@v{version}
         docs/workflows/ci_update_dependencies.md,uses: SINTEF/ci-cd/\.github/workflows/ci_update_dependencies\.yml@v[0-9]+.*$,uses: SINTEF/ci-cd/.github/workflows/ci_update_dependencies.yml@v{version}
+        docs/workflows/ci_tests.md,uses: SINTEF/ci-cd/\.github/workflows/ci_tests\.yml@v[0-9]+.*$,uses: SINTEF/ci-cd/.github/workflows/ci_tests.yml@v{version}
         .github/workflows/cd_release.yml,https://github\.com/SINTEF/ci-cd\.git@v[0-9]+.*$,https://github.com/SINTEF/ci-cd.git@v{version}
         .github/workflows/ci_cd_updated_default_branch.yml,https://github\.com/SINTEF/ci-cd\.git@v[0-9]+.*$,https://github.com/SINTEF/ci-cd.git@v{version}
         .github/workflows/ci_check_pyproject_dependencies.yml,https://github\.com/SINTEF/ci-cd\.git@v[0-9]+.*$,https://github.com/SINTEF/ci-cd.git@v{version}
         docs/workflows/cd_release.md,\(https://github\.com/SINTEF/ci-cd/blob/v[0-9]+.*/\.github/workflows/_local_cd_release\.yml\),(https://github.com/SINTEF/ci-cd/blob/v{version}/.github/workflows/_local_cd_release.yml)
+        .github/workflows/ci_tests.yml,https://github\.com/SINTEF/ci-cd\.git@v[0-9]+.*$,https://github.com/SINTEF/ci-cd.git@v{version}
     secrets:
       PAT: ${{ secrets.RELEASE_PAT }}

--- a/.github/workflows/ci_update_dependencies.yml
+++ b/.github/workflows/ci_update_dependencies.yml
@@ -100,11 +100,6 @@ jobs:
       if: inputs.update_pre-commit
       run: |
         pre-commit autoupdate
-        if [ -n "$(grep -Pzl 'repo:\s*https://github.com/SINTEF/ci-cd' .pre-commit-config.yaml)" ] \
-        then
-          # Using hooks from this repository
-          pre-commit autoupdate --repo https://github.com/SINTEF/ci-cd --freeze
-        fi
 
         if [ -n "$(git status --porcelain .pre-commit-config.yaml)" ]; then
           # Set environment variable notifying next steps that the hooks changed

--- a/.github/workflows/ci_update_dependencies.yml
+++ b/.github/workflows/ci_update_dependencies.yml
@@ -100,10 +100,9 @@ jobs:
       if: inputs.update_pre-commit
       run: |
         pre-commit autoupdate
-        if [ -n "$(grep -Pzl 'repo:\s*https://github.com/SINTEF/ci-cd\s*\n\s*rev:\s*v1' .pre-commit-config.yaml)" ] || \
-           [ -n "$(grep -Pzl 'repo:\s*https://github.com/SINTEF/ci-cd\s*\n\s*rev:.*# frozen: v1' .pre-commit-config.yaml)" ]
+        if [ -n "$(grep -Pzl 'repo:\s*https://github.com/SINTEF/ci-cd' .pre-commit-config.yaml)" ] \
         then
-          # Using hooks from this repository AND using a "moving" tag ('v1')
+          # Using hooks from this repository
           pre-commit autoupdate --repo https://github.com/SINTEF/ci-cd --freeze
         fi
 


### PR DESCRIPTION
Intead of using a moving V1 tag, we change to using the actual version tag