### PR TITLE
Changes prior to auto-merge

### DIFF
--- a/.github/workflows/ci_automerge_prs.yml
+++ b/.github/workflows/ci_automerge_prs.yml
@@ -2,9 +2,28 @@ name: CI - Activate auto-merging for PRs
 
 on:
   workflow_call:
+    inputs:
+      perform_changes:
+        description: "Whether or not to perform and commit changes to the PR branch prior to activating auto-merge."
+        required: false
+        type: boolean
+        default: false
+      # REQUIRED if perform_changes is True
+      git_username:
+        description: "A git username (used to set the 'user.name' config option). Required if `perform_changes` is 'true'."
+        required: false
+        type: string
+      git_email:
+        description: "A git user's email address (used to set the 'user.email' config option). Required if `perform_changes` is 'true'."
+        required: false
+        type: string
+      changes:
+        description: "A file to run in the local repository (relative path from the root of the repository) or a multi-line string of bash commands to run. Required if `perform_changes` is 'true'."
+        required: false
+        type: string
     secrets:
       PAT:
-        description: "A personal access token (PAT) with rights to update the `release_branch`. This will fallback on `GITHUB_TOKEN`."
+        description: "A personal access token (PAT) with rights to update the PR head branch. This will fallback on `GITHUB_TOKEN`."
         required: false
 
 jobs:
@@ -19,6 +38,37 @@ jobs:
       with:
         fetch-depth: 0
         ref: ${{ github.event.pull_request.head.ref }}
+
+    - name: Perform local changes
+      if: inputs.perform_changes
+      run: |
+        if [ -z "${{ inputs.git_username }}" ] || [ -z "${{ inputs.git_email }}" ] || [ -z "${{ changes }}" ]; then
+          echo "git_username, git_email and changes MUST be supplied."
+          exit 1
+        fi
+
+        TEMP_RUN_FILE=".tmp_${{ github.run_id }}_${{ github.run_number }}_${{ github.run_attempt }}.sh"
+        printf "${{ input.changes }}" >> ${TMP_RUN_FILE}
+
+        chmod +x ${TEMP_RUN_FILE}
+        ./${TEMP_RUN_FILE}
+
+    - name: Set up git user and commit changes
+      if: inputs.perform_changes
+      run: |
+        git config --global user.name "${{ inputs.git_username }}"
+        git config --global user.email "${{ inputs.git_email }}"
+
+        git commit -am "Auto-merge extra changes."
+
+    - name: Push changes to '${{ github.event.pull_request.head.ref }}'
+      if: inputs.perform_changes
+      uses: CasperWA/push-protected@v2
+      with:
+        token: ${{ secrets.PAT || secrets.GITHUB_TOKEN }}
+        branch: ${{ github.event.pull_request.head.ref }}
+        sleep: 15
+        unprotect_reviews: true
 
     - name: Activate auto-merge
       run: |

--- a/docs/workflows/ci_automerge_prs.md
+++ b/docs/workflows/ci_automerge_prs.md
@@ -4,6 +4,17 @@
 
 Activate auto-merging for a PR.
 
+It is possible to introduce changes to the PR head branch prior to activating the auto-merging, if so desired.
+This is done by setting `perform_changes` to `'true'` and setting the other inputs accordingly, as they are now required.
+See [Inputs](#inputs) below for a full overview of the available inputs.
+
+The `changes` input can be both a path to a bash file that should be run, or a single or multi-line string of bash commands to run.
+Afterwards any and all changes in the repository will be committed and pushed to the PR head branch.
+
+The motivation for being able to run changes prior to auto-merging, is to update or affect the repository files according to the specific PR being auto-merged.
+Usually auto-merging is activated for [dependabot](https://docs.github.com/en/code-security/dependabot) branches, i.e., when a dependency/requirement is updated.
+Hence, the changes could include updating this dependency in documentation files or similar, where it will not be updated otherwise.
+
 ## Expectations
 
 The `PAT` secret must represent a user with the rights to activate auto-merging.
@@ -12,7 +23,12 @@ This workflow can _only_ be called if the triggering event from the caller workf
 
 ## Inputs
 
-There are no inputs for this workflow.
+| **Name** | **Description** | **Required** | **Default** | **Type** |
+|:--- |:--- |:---:|:---:|:---:|
+| `perform_changes` | Whether or not to perform and commit changes to the PR branch prior to activating auto-merge. | No | | _boolean_ |
+| `git_username` | A git username (used to set the 'user.name' config option).</br>**Required** if `perform_changes` is 'true'. | No | | _string_ |
+| `git_email` | A git user's email address (used to set the 'user.email' config option).</br>**Required** if `perform_changes` is 'true'. | No | | _string_ |
+| `changes` | A file to run in the local repository (relative path from the root of the repository) or a multi-line string of bash commands to run.</br>**Required** if `perform_changes` is 'true'. | No | | _string_ |
 
 ## Secrets
 
@@ -38,6 +54,75 @@ jobs:
     name: Call external workflow
     uses: SINTEF/ci-cd/.github/workflows/ci_automerge_prs.yml@v1
     if: github.repository_owner == 'SINTEF' && ( ( startsWith(github.event.pull_request.head.ref, 'dependabot/') && github.actor == 'dependabot[bot]' ) || ( github.event.pull_request.head.ref == 'ci/update-pyproject' && github.actor == 'CasperWA' ) )
+    secrets:
+      PAT: ${{ secrets.RELEASE_PAT }}
+```
+
+A couple of usage examples when adding changes:
+
+Here, referencing a bash script file for the changes.
+
+```yaml
+name: CI - Activate auto-merging for Dependabot PRs
+
+on:
+  pull_request_target:
+    branches:
+    - ci/dependency-updates
+
+jobs:
+  update-dependency-branch:
+    name: Call external workflow
+    uses: SINTEF/ci-cd/.github/workflows/ci_automerge_prs.yml@v1
+    if: github.repository_owner == 'SINTEF' && ( ( startsWith(github.event.pull_request.head.ref, 'dependabot/') && github.actor == 'dependabot[bot]' ) || ( github.event.pull_request.head.ref == 'ci/update-pyproject' && github.actor == 'CasperWA' ) )
+    with:
+      perform_changes: true
+      git_username: "Casper Welzel Andersen"
+      git_email: "CasperWA@github.com"
+      changes: ".ci/pre_automerge.sh"
+    secrets:
+      PAT: ${{ secrets.RELEASE_PAT }}
+```
+
+Here, writing out the changes explicitly in the job.
+
+```yaml
+name: CI - Activate auto-merging for Dependabot PRs
+
+on:
+  pull_request_target:
+    branches:
+    - ci/dependency-updates
+
+jobs:
+  update-dependency-branch:
+    name: Call external workflow
+    uses: SINTEF/ci-cd/.github/workflows/ci_automerge_prs.yml@v1
+    if: github.repository_owner == 'SINTEF' && ( ( startsWith(github.event.pull_request.head.ref, 'dependabot/') && github.actor == 'dependabot[bot]' ) || ( github.event.pull_request.head.ref == 'ci/update-pyproject' && github.actor == 'CasperWA' ) )
+    with:
+      perform_changes: true
+      git_username: "Casper Welzel Andersen"
+      git_email: "CasperWA@github.com"
+      changes: |
+        PYTHON=
+        python --version || PYTHON=NO
+        if [ -n "${PYTHON} ]; then
+          echo "Python not detected on the system."
+          exit 1
+        fi
+        PIP=
+        python -m pip --version || PIP=NO
+        if [ -n "${PYTHON} ]; then
+          echo "pip not detected to be installed for Python."
+          exit 1
+        fi
+
+        python -m pip install -U pip
+        pip install -U setuptools wheel
+        pip install pre-commit
+
+        pre-commit autoupdate
+        pre-commit run --all-files || :
     secrets:
       PAT: ${{ secrets.RELEASE_PAT }}
 ```


### PR DESCRIPTION
Closes #69 

Make it possible to perform changes prior to activating auto-merging during the auto-merging workflow.