### PR TITLE
Always try to use `PAT` prior to `GITHUB_TOKEN`

### DIFF
--- a/.github/workflows/cd_release.yml
+++ b/.github/workflows/cd_release.yml
@@ -136,7 +136,7 @@ jobs:
     - name: Update changelog
       uses: CharMixer/auto-changelog-action@v1
       with:
-        token: ${{ secrets.GITHUB_TOKEN }}
+        token: ${{ secrets.PAT || secrets.GITHUB_TOKEN }}
         release_branch: ${{ inputs.release_branch }}
         exclude_tags_regex: "${{ inputs.changelog_exclude_tags_regex }}"
         exclude_labels: "${{ inputs.changelog_exclude_labels }}"
@@ -228,7 +228,7 @@ jobs:
     - name: Create release-specific changelog
       uses: CharMixer/auto-changelog-action@v1
       with:
-        token: ${{ secrets.GITHUB_TOKEN }}
+        token: ${{ secrets.PAT || secrets.GITHUB_TOKEN }}
         release_branch: ${{ inputs.release_branch }}
         since_tag: "${{ env.PREVIOUS_VERSION }}"
         output: "release_changelog.md"
@@ -241,7 +241,7 @@ jobs:
         cat release_changelog.md >> release_body.md
         gh api /repos/${{ github.repository }}/releases/${{ github.event.release.id }} -X PATCH -F body='@release_body.md'
       env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        GITHUB_TOKEN: ${{ secrets.PAT || secrets.GITHUB_TOKEN }}
 
     - name: Publish package to TestPyPI
       if: inputs.test && inputs.publish_on_pypi && inputs.python_package

--- a/.github/workflows/ci_cd_updated_default_branch.yml
+++ b/.github/workflows/ci_cd_updated_default_branch.yml
@@ -136,7 +136,7 @@ jobs:
           echo "RELEASE_RUN=false" >> $GITHUB_ENV
         fi
       env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        GITHUB_TOKEN: ${{ secrets.PAT || secrets.GITHUB_TOKEN }}
 
     - name: Checkout ${{ github.repository }}
       if: env.RELEASE_RUN == 'false'
@@ -278,7 +278,7 @@ jobs:
       if: env.RELEASE_RUN == 'false'
       uses: CharMixer/auto-changelog-action@v1
       with:
-        token: ${{ secrets.GITHUB_TOKEN }}
+        token: ${{ secrets.PAT || secrets.GITHUB_TOKEN }}
         release_branch: ${{ inputs.default_repo_branch }}
         exclude_tags_regex: "${{ inputs.changelog_exclude_tags_regex }}"
         exclude_labels: "${{ inputs.changelog_exclude_labels }}"
@@ -342,7 +342,7 @@ jobs:
         fi
         if [ -f ".tmp_file.txt" ]; then rm -f .tmp_file.txt; fi
       env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        GITHUB_TOKEN: ${{ secrets.PAT || secrets.GITHUB_TOKEN }}
 
     - name: Push to '${{ inputs.permanent_dependencies_branch }}'
       if: "! inputs.test"


### PR DESCRIPTION
Fixes #104 

For _every_ single place where `GITHUB_TOKEN` is used, we should try to use the `PAT` secret first and then fallback to using `GITHUB_TOKEN` if `PAT` is not defined. This fallback is done by the `||` operator in GH Actions workflow logic.