### PR TITLE
Add API reference documentation for `ci-cd`

### DIFF
--- a/.github/workflows/_local_ci_cd_updated_main.yml
+++ b/.github/workflows/_local_ci_cd_updated_main.yml
@@ -16,7 +16,7 @@ jobs:
       default_repo_branch: main
       update_docs: true
       doc_extras: "[docs]"
-      update_python_api_ref: false
+      update_python_api_ref: true
       update_docs_landing_page: false
       changelog_exclude_tags_regex: "^v[0-9]+$"
       test: false

--- a/.github/workflows/_local_ci_cd_updated_main.yml
+++ b/.github/workflows/_local_ci_cd_updated_main.yml
@@ -18,6 +18,7 @@ jobs:
       doc_extras: "[docs]"
       update_python_api_ref: true
       update_docs_landing_page: false
+      package_dirs: ci_cd
       changelog_exclude_tags_regex: "^v[0-9]+$"
       test: false
     secrets:

--- a/.github/workflows/_local_ci_tests.yml
+++ b/.github/workflows/_local_ci_tests.yml
@@ -28,7 +28,7 @@ jobs:
       build_cmd: flit build
 
       # build docs
-      update_python_api_ref: false
+      update_python_api_ref: true
       update_docs_landing_page: false
       debug: false
 

--- a/.github/workflows/_local_ci_tests.yml
+++ b/.github/workflows/_local_ci_tests.yml
@@ -30,6 +30,7 @@ jobs:
       # build docs
       update_python_api_ref: true
       update_docs_landing_page: false
+      package_dirs: ci_cd
       debug: false
 
   pytest:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -53,6 +53,13 @@ repos:
     hooks:
     - id: mypy
 
+  - repo: https://github.com/SINTEF/ci-cd
+    rev: v2.0.0
+    hooks:
+    - id: docs-api-reference
+      args:
+      - "--package-dir=ci_cd"
+
   - repo: local
     hooks:
     # pylint is a Python linter

--- a/ci_cd/tasks/update_deps.py
+++ b/ci_cd/tasks/update_deps.py
@@ -112,6 +112,7 @@ def update_deps(  # pylint: disable=too-many-branches,too-many-locals,too-many-s
             print(msg)
             error = True
             continue
+
         version_spec = VersionSpec(**match.groupdict())
         LOGGER.debug("version_spec: %s", version_spec)
 

--- a/docs/api_reference/.pages
+++ b/docs/api_reference/.pages
@@ -1,0 +1,1 @@
+title: "API Reference"

--- a/docs/api_reference/main.md
+++ b/docs/api_reference/main.md
@@ -1,0 +1,3 @@
+# main
+
+::: ci_cd.main

--- a/docs/api_reference/tasks/.pages
+++ b/docs/api_reference/tasks/.pages
@@ -1,0 +1,1 @@
+title: "tasks"

--- a/docs/api_reference/utils.md
+++ b/docs/api_reference/utils.md
@@ -1,0 +1,3 @@
+# utils
+
+::: ci_cd.utils

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -84,6 +84,8 @@ nav:
     - ... | flat | hooks/**
   - License: LICENSE.md
   - Changelog: CHANGELOG.md
+  - Developers:
+    - ... | api_reference/**
 
 watch:
   - "ci_cd"


### PR DESCRIPTION
Part 2 of closing #95.

To do:
- [x] Rebase on `main` after #109 has been merged.

Add API reference documentation for _this_ repository to the documentation at [SINTEF.github.io/ci-cd](https://SINTEF.github.io/ci-cd).

Note, this is part 2 of 3 of a new set of PRs that replace #99.

Closes #113 