### PR TITLE
Implement `ignore` option for `update-deps` task

### DIFF
--- a/.github/workflows/ci_check_pyproject_dependencies.yml
+++ b/.github/workflows/ci_check_pyproject_dependencies.yml
@@ -41,6 +41,11 @@ on:
         required: false
         type: string
         default: ""
+      ignore:
+        description: "Create ignore conditions for certain dependencies. A multi-line string of ignore rules, where each line is an ellipsis-separated (`...`) string of key/value-pairs. One line per dependency. This option is similar to the `ignore` option of Dependabot."
+        required: false
+        type: string
+        default: ""
     secrets:
       PAT:
         description: "A personal access token (PAT) with rights to update the `permanent_dependencies_branch`. This will fallback on `GITHUB_TOKEN`."
@@ -83,7 +88,14 @@ jobs:
           FAIL_FAST=
         fi
 
-        ci-cd update-deps --root-repo-path="${PWD}" ${FAIL_FAST}
+        IGNORE_OPTIONS=()
+        while IFS= read -r line; do
+          if [ -n "${line}" ]; then IGNORE_OPTIONS+=(--ignore-options="${line}"); fi
+        done <<< "${{ inputs.ignore }}"
+
+        ci-cd update-deps ${FAIL_FAST} \
+          --root-repo-path="${PWD}" \
+          "${IGNORE_OPTIONS[@]}"
 
         if [ -n "$(git status --porcelain pyproject.toml)" ]; then
           echo "UPDATE_DEPS=true" >> $GITHUB_ENV

--- a/ci_cd/exceptions.py
+++ b/ci_cd/exceptions.py
@@ -1,0 +1,13 @@
+"""CI/CD-specific exceptions."""
+
+
+class CICDException(Exception):
+    """Top-level package exception class."""
+
+
+class InputError(ValueError, CICDException):
+    """There is an error with the input given to a task."""
+
+
+class InputParserError(InputError):
+    """The input could not be parsed, it may be wrongly formatted."""

--- a/ci_cd/tasks/update_deps.py
+++ b/ci_cd/tasks/update_deps.py
@@ -3,6 +3,8 @@
 Update dependencies in a `pyproject.toml` file.
 """
 # pylint: disable=duplicate-code
+from __future__ import annotations
+
 import logging
 import operator
 import re

--- a/ci_cd/tasks/update_deps.py
+++ b/ci_cd/tasks/update_deps.py
@@ -4,6 +4,7 @@ Update dependencies in a `pyproject.toml` file.
 """
 # pylint: disable=duplicate-code
 import logging
+import operator
 import re
 import sys
 from collections import namedtuple
@@ -13,9 +14,12 @@ from typing import TYPE_CHECKING
 import tomlkit
 from invoke import task
 
+from ci_cd.exceptions import InputParserError, InputError
 from ci_cd.utils import update_file
 
 if TYPE_CHECKING:  # pragma: no cover
+    from typing import Literal
+
     from invoke import Context, Result
 
 
@@ -33,10 +37,24 @@ LOGGER.setLevel(logging.DEBUG)
             "A resolvable path to the root directory of the repository folder."
         ),
         "pre-commit": "Whether or not this task is run as a pre-commit hook.",
-    }
+        "ignore": (
+            "Ignore-rules based on the `ignore` config option of Dependabot. It "
+            "should be of the format: key=value...key=value, i.e., an ellipsis "
+            "(`...`) separator and then equal-sign-separated key/value-pairs. "
+            "Alternatively, the `--ignore-separator` can be set to something else to "
+            "overwrite the ellipsis. The only supported keys are: `dependency-name`, "
+            "`versions`, and `update-types`. Can be supplied multiple times per "
+            "`dependency-name`."
+        ),
+        "ignore-separator": (
+            "Value to use instead of ellipsis (`...`) as a separator in `--ignore` "
+            "key/value-pairs."
+        ),
+    },
+    iterable=["ignore"],
 )
 def update_deps(  # pylint: disable=too-many-branches,too-many-locals,too-many-statements
-    context, root_repo_path=".", fail_fast=False, pre_commit=False
+    context, root_repo_path=".", fail_fast=False, pre_commit=False, ignore=None, ignore_separator="..."
 ):
     """Update dependencies in specified Python package's `pyproject.toml`."""
     if TYPE_CHECKING:  # pragma: no cover
@@ -44,6 +62,10 @@ def update_deps(  # pylint: disable=too-many-branches,too-many-locals,too-many-s
         root_repo_path: str = root_repo_path  # type: ignore[no-redef]
         fail_fast: bool = fail_fast  # type: ignore[no-redef]
         pre_commit: bool = pre_commit  # type: ignore[no-redef]
+        ignore_separator: str = ignore_separator
+
+    if not ignore:
+        ignore: list[str] = []
 
     VersionSpec = namedtuple(
         "VersionSpec",
@@ -57,6 +79,12 @@ def update_deps(  # pylint: disable=too-many-branches,too-many-locals,too-many-s
             "environment_marker",
         ],
     )
+
+    try:
+        ignore_rules = parse_ignore_entries(ignore, ignore_separator)
+    except InputError as exc:
+        sys.exit(f"Error: Could not parse ignore options.\nException: {exc}")
+    LOGGER.debug("Parsed ignore rules: %s", ignore_rules)
 
     if pre_commit and root_repo_path == ".":
         # Use git to determine repo root
@@ -94,9 +122,11 @@ def update_deps(  # pylint: disable=too-many-branches,too-many-locals,too-many-s
     for line in dependencies:
         match = re.match(
             r"^(?P<full_dependency>(?P<package>[a-zA-Z0-9_.-]+)(?:\s*\[.*\])?)\s*"
-            r"(?:(?P<url_version>@\s*\S+)|"
+            r"(?:"
+            r"(?P<url_version>@\s*\S+)|"
             r"(?P<operator>>|<|<=|>=|==|!=|~=)\s*"
-            r"(?P<version>[0-9]+(?:\.[0-9]+){0,2}))?\s*"
+            r"(?P<version>[0-9]+(?:\.[0-9]+){0,2})"
+            r")?\s*"
             r"(?P<extra_operator_version>(?:,(?:>|<|<=|>=|==|!=|~=)\s*"
             r"[0-9]+(?:\.[0-9]+){0,2}\s*)+)*"
             r"(?P<environment_marker>;.+)*$",
@@ -178,6 +208,7 @@ def update_deps(  # pylint: disable=too-many-branches,too-many-locals,too-many-s
             error = True
             continue
 
+        # Check whether pyproject.toml already uses the latest version
         latest_version = match.group("version").split(".")
         for index, version_part in enumerate(version_spec.version.split(".")):
             if version_part != latest_version[index]:
@@ -185,6 +216,29 @@ def update_deps(  # pylint: disable=too-many-branches,too-many-locals,too-many-s
         else:
             already_handled_packages.add(version_spec.package)
             continue
+
+        # Apply ignore rules
+        if version_spec.package in ignore_rules or "*" in ignore_rules:
+            versions = []
+            update_types = {}
+
+            if "*" in ignore_rules:
+                versions, update_types = parse_ignore_rules(ignore_rules["*"])
+
+            if version_spec.package in ignore_rules:
+                parsed_rules = parse_ignore_rules(ignore_rules[version_spec.package])
+
+                versions.extend(parsed_rules[0])
+                update_types.update(parsed_rules[1])
+
+            if ignore_version(
+                current=version_spec.version.split("."),
+                latest=latest_version,
+                version_rules=versions,
+                semver_rules=update_types,
+            ):
+                already_handled_packages.add(version_spec.package)
+                continue
 
         if not error:
             # Update pyproject.toml
@@ -225,3 +279,226 @@ def update_deps(  # pylint: disable=too-many-branches,too-many-locals,too-many-s
         )
     else:
         print("No dependency updates available.")
+
+
+def parse_ignore_entries(entries: list[str], separator: str) -> 'dict[str, dict[Literal["versions", "update-types"], list[str]]]':
+    """Parser for the `--ignore` option.
+
+    The `--ignore` option values are given as key/value-pairs in the form:
+    `key=value...key=value`. Here `...` is the separator value supplied by
+    `--ignore-separator`.
+
+    Parameters:
+        entries: The list of supplied `--ignore` options.
+        separator: The supplied `--ignore-separator` value.
+
+    Returns:
+        A parsed mapping of dependencies to ignore rules.
+
+    """
+    ignore_entries: 'dict[str, dict[Literal["versions", "update-types"], list[str]]]' = {}
+
+    for entry in entries:
+        pairs = entry.split(separator, maxsplit=2)
+        for pair in pairs:
+            if separator in pair:
+                raise InputParserError(
+                    "More than three key/value-pairs were given for an `--ignore` "
+                    "option, while there are only three allowed key names. Input "
+                    f"value: --ignore={entry}"
+                )
+
+        ignore_entry = {}
+        for pair in pairs:
+            match = re.match(
+                r"^(?P<key>dependency-name|versions|update-types)=(?P<value>.*)$",
+                pair,
+            )
+            if match is None:
+                raise InputParserError(
+                    f"Could not parse ignore configuration: {pair!r} (part of the "
+                    f"ignore option: {entry!r}"
+                )
+            if match.group("key") in ignore_entry:
+                raise InputParserError(
+                    "An ignore configuration can only be given once per option. The "
+                    f"configuration key {match.group('key')!r} was found multiple "
+                    f"times in the option {entry!r}"
+                )
+
+            ignore_entry[match.group("key")] = match.group("value").strip()
+
+        if "dependency-name" not in ignore_entry:
+            raise InputError(
+                "Ignore option entry missing required 'dependency-name' "
+                f"configuration. Ignore option entry: {entry}"
+            )
+
+        dependency_name = ignore_entry.pop("dependency-name")
+        if dependency_name not in ignore_entries:
+            ignore_entries[dependency_name] = {key: [value] for key, value in ignore_entry.items()}
+        else:
+            for key, value in ignore_entry.items():
+                ignore_entries[dependency_name][key].append(value)
+
+    return ignore_entries
+
+
+def parse_ignore_rules(rules: "dict[Literal['versions', 'update-types'], list[str]]") -> "tuple[list[dict[Literal['operator', 'version'], str]], dict[Literal['version-update'], list[Literal['major', 'minor', 'patch']]]]":
+    """Parser for a specific set of ignore rules.
+
+    Parameters:
+        rules: A set of ignore rules for one or more packages.
+
+    Returns:
+        A tuple of the parsed 'versions' and 'update-types' entries as dictionaries.
+
+    """
+    if not rules:
+        # Ignore package altogether
+        return [{"operator": ">=", "version": "0"}], {}
+
+    versions = []
+    update_types = {}
+
+    if "versions" in rules:
+        for versions_entry in rules["versions"]:
+            match = re.match(
+                r"^(?P<operator>>|<|<=|>=|==|!=|~=)\s*"
+                r"(?P<version>[0-9]+(?:\.[0-9]+){0,2})$",
+                versions_entry,
+            )
+            if match is None:
+                raise InputParserError(
+                    "Ignore option's 'versions' value cannot be parsed. It "
+                    "must be a single operator followed by a version number.\n"
+                    f"Unparseable 'versions' value: {versions_entry!r}"
+                )
+            versions.append(match.groupdict())
+
+    if "update-types" in rules:
+        update_types["version-update"] = []
+        for update_type_entry in rules["update-types"]:
+            match = re.match(
+                r"^version-update:semver-(?P<semver_part>major|minor|patch)$",
+                update_type_entry,
+            )
+            if match is None:
+                raise InputParserError(
+                    "Ignore option's 'update-types' value cannot be parsed."
+                    " It must be either: 'version-update:semver-major', "
+                    "'version-update:semver-minor' or "
+                    "'version-update:semver-patch'.\nUnparseable 'update-types' "
+                    f"value: {update_type_entry!r}"
+                )
+            update_types["version-update"].append(match.group("semver_part"))
+
+    return versions, update_types
+
+
+def ignore_version(
+    current: list[str],
+    latest: list[str],
+    version_rules: "list[dict[Literal['operator', 'version'], str]]",
+    semver_rules: "dict[Literal['version-update'], list[Literal['major', 'minor', 'patch']]]",
+) -> bool:
+    """Determine whether the latest version can be ignored.
+
+    Parameters:
+        current: The current version as a list of version parts. It's expected, but not
+            required, the version is a semantic version.
+        latest: The latest version as a list of version parts. It's expected, but not
+            required, the version is a semantic version.
+        version_rules: Version ignore rules.
+        semver_rules: Semantic version ignore rules.
+
+    Returns:
+        Whether or not the latest version can be ignored based on the version and
+        semantic version ignore rules.
+
+    """
+    # ignore all updates
+    if not version_rules and not semver_rules:
+        # A package name has been specified without specific rules, ignore all updates for package.
+        return True
+
+    # version
+    operators_mapping = {
+        ">": operator.gt,
+        "<": operator.lt,
+        "<=": operator.le,
+        ">=": operator.ge,
+        "==": operator.eq,
+        "!=": operator.ne,
+    }
+
+    decision_version_rules = []
+    for version_rule in version_rules:
+        decision_version_rule = False
+        split_version_rule = version_rule.get("version", "").split(".")
+
+        if version_rule.get("operator", "") in operators_mapping:
+            # Extend version rule with zeros if needed
+            if len(split_version_rule) < len(latest):
+                split_version_rule.extend(["0"] * (len(latest) - len(split_version_rule)))
+            assert len(split_version_rule) == len(latest)
+
+            any_all_logic = (
+                all
+                if "=" in version_rule["operator"] and version_rule["operator"] != "!="
+                else any
+            )
+            if any_all_logic(
+                operators_mapping[version_rule["operator"]](latest_part, version_rule_part)
+                for latest_part, version_rule_part in zip(latest, split_version_rule)
+            ):
+                decision_version_rule = True
+        elif "~=" == version_rule.get("operator", ""):
+            if len(split_version_rule) == 1:
+                raise InputError(
+                    "Ignore option value error. For the 'versions' config key, when using "
+                    "the '~=' operator more than a single version part MUST be specified. "
+                    "E.g., '~=2' is disallowed, instead use '~=2.0' or similar."
+                )
+
+            if all(
+                latest_part >= version_rule_part
+                for latest_part, version_rule_part in zip(latest, split_version_rule)
+            ) and all(
+                latest_part == version_rule_part
+                for latest_part, version_rule_part in zip(latest[:-1], split_version_rule[:-1])
+            ):
+                decision_version_rule = True
+        elif version_rule.get("operator", ""):
+            # Should not be possible to reach if using `parse_ignore_rules()`
+            # But for completion, and understanding, this is still kept.
+            raise InputParserError(
+                "Unknown ignore options 'versions' config value operator: "
+                f"{version_rule['operator']}"
+            )
+        decision_version_rules.append(decision_version_rule)
+
+    # If ALL version rules AND'ed together are True, ignore the version.
+    if decision_version_rules and all(decision_version_rules):
+        return True
+
+    # semver
+    # If ANY of the semver rules are True, ignore the version.
+    if "version-update" in semver_rules:
+        if any(_ not in ["major", "minor", "patch"] for _ in semver_rules["version-update"]):
+            raise InputParserError(
+                f"Only valid values for 'version-update' are 'major', 'minor', and "
+                f"'patch' (you gave {semver_rules['version-update']!r})."
+            )
+
+        if "major" in semver_rules["version-update"]:
+            if latest[0] != current[0]:
+                return True
+        elif "minor" in semver_rules["version-update"]:
+            if len(latest) >= 2 and len(current) >= 2 and latest[1] > current[1] and latest[0] == current[0]:
+                return True
+        elif "patch" in semver_rules["version-update"]:
+            if len(latest) >= 3 and len(current) >= 3 and latest[2] > current[2] and latest[0] == current[0] and latest[1] == current[1]:
+                return True
+
+    return False

--- a/ci_cd/tasks/update_deps.py
+++ b/ci_cd/tasks/update_deps.py
@@ -14,7 +14,7 @@ from typing import TYPE_CHECKING
 import tomlkit
 from invoke import task
 
-from ci_cd.exceptions import InputParserError, InputError
+from ci_cd.exceptions import CICDException, InputError, InputParserError
 from ci_cd.utils import update_file
 
 if TYPE_CHECKING:  # pragma: no cover
@@ -54,7 +54,12 @@ LOGGER.setLevel(logging.DEBUG)
     iterable=["ignore"],
 )
 def update_deps(  # pylint: disable=too-many-branches,too-many-locals,too-many-statements
-    context, root_repo_path=".", fail_fast=False, pre_commit=False, ignore=None, ignore_separator="..."
+    context,
+    root_repo_path=".",
+    fail_fast=False,
+    pre_commit=False,
+    ignore=None,
+    ignore_separator="...",
 ):
     """Update dependencies in specified Python package's `pyproject.toml`."""
     if TYPE_CHECKING:  # pragma: no cover
@@ -62,10 +67,10 @@ def update_deps(  # pylint: disable=too-many-branches,too-many-locals,too-many-s
         root_repo_path: str = root_repo_path  # type: ignore[no-redef]
         fail_fast: bool = fail_fast  # type: ignore[no-redef]
         pre_commit: bool = pre_commit  # type: ignore[no-redef]
-        ignore_separator: str = ignore_separator
+        ignore_separator: str = ignore_separator  # type: ignore[no-redef]
 
     if not ignore:
-        ignore: list[str] = []
+        ignore: list[str] = []  # type: ignore[no-redef]
 
     VersionSpec = namedtuple(
         "VersionSpec",
@@ -105,7 +110,7 @@ def update_deps(  # pylint: disable=too-many-branches,too-many-locals,too-many-s
         pyproject.get("project", {}).get("requires-python", ""),
     )
     if not match:
-        raise ValueError(
+        raise CICDException(
             "No minimum Python version requirement given in pyproject.toml!"
         )
     py_version = match.group("version")
@@ -219,8 +224,10 @@ def update_deps(  # pylint: disable=too-many-branches,too-many-locals,too-many-s
 
         # Apply ignore rules
         if version_spec.package in ignore_rules or "*" in ignore_rules:
-            versions = []
-            update_types = {}
+            versions: "list[dict[Literal['operator', 'version'], str]]" = []
+            update_types: "dict[Literal['version-update'], list[Literal['major', 'minor', 'patch']]]" = (  # pylint: disable=line-too-long
+                {}
+            )
 
             if "*" in ignore_rules:
                 versions, update_types = parse_ignore_rules(ignore_rules["*"])
@@ -281,7 +288,9 @@ def update_deps(  # pylint: disable=too-many-branches,too-many-locals,too-many-s
         print("No dependency updates available.")
 
 
-def parse_ignore_entries(entries: list[str], separator: str) -> 'dict[str, dict[Literal["versions", "update-types"], list[str]]]':
+def parse_ignore_entries(
+    entries: list[str], separator: str
+) -> 'dict[str, dict[Literal["versions", "update-types"], list[str]]]':
     """Parser for the `--ignore` option.
 
     The `--ignore` option values are given as key/value-pairs in the form:
@@ -296,7 +305,9 @@ def parse_ignore_entries(entries: list[str], separator: str) -> 'dict[str, dict[
         A parsed mapping of dependencies to ignore rules.
 
     """
-    ignore_entries: 'dict[str, dict[Literal["versions", "update-types"], list[str]]]' = {}
+    ignore_entries: 'dict[str, dict[Literal["versions", "update-types"], list[str]]]' = (
+        {}
+    )
 
     for entry in entries:
         pairs = entry.split(separator, maxsplit=2)
@@ -308,7 +319,9 @@ def parse_ignore_entries(entries: list[str], separator: str) -> 'dict[str, dict[
                     f"value: --ignore={entry}"
                 )
 
-        ignore_entry = {}
+        ignore_entry: 'dict[Literal["dependency-name", "versions", "update-types"], str]' = (  # pylint: disable=line-too-long
+            {}
+        )
         for pair in pairs:
             match = re.match(
                 r"^(?P<key>dependency-name|versions|update-types)=(?P<value>.*)$",
@@ -326,7 +339,7 @@ def parse_ignore_entries(entries: list[str], separator: str) -> 'dict[str, dict[
                     f"times in the option {entry!r}"
                 )
 
-            ignore_entry[match.group("key")] = match.group("value").strip()
+            ignore_entry[match.group("key")] = match.group("value").strip()  # type: ignore[index]  # pylint: disable=line-too-long
 
         if "dependency-name" not in ignore_entry:
             raise InputError(
@@ -334,17 +347,21 @@ def parse_ignore_entries(entries: list[str], separator: str) -> 'dict[str, dict[
                 f"configuration. Ignore option entry: {entry}"
             )
 
-        dependency_name = ignore_entry.pop("dependency-name")
+        dependency_name: str = ignore_entry.pop("dependency-name", "")
         if dependency_name not in ignore_entries:
-            ignore_entries[dependency_name] = {key: [value] for key, value in ignore_entry.items()}
+            ignore_entries[dependency_name] = {
+                key: [value] for key, value in ignore_entry.items()  # type: ignore[misc]
+            }
         else:
             for key, value in ignore_entry.items():
-                ignore_entries[dependency_name][key].append(value)
+                ignore_entries[dependency_name][key].append(value)  # type: ignore[index]
 
     return ignore_entries
 
 
-def parse_ignore_rules(rules: "dict[Literal['versions', 'update-types'], list[str]]") -> "tuple[list[dict[Literal['operator', 'version'], str]], dict[Literal['version-update'], list[Literal['major', 'minor', 'patch']]]]":
+def parse_ignore_rules(
+    rules: "dict[Literal['versions', 'update-types'], list[str]]",
+) -> "tuple[list[dict[Literal['operator', 'version'], str]], dict[Literal['version-update'], list[Literal['major', 'minor', 'patch']]]]":  # pylint: disable=line-too-long
     """Parser for a specific set of ignore rules.
 
     Parameters:
@@ -358,8 +375,10 @@ def parse_ignore_rules(rules: "dict[Literal['versions', 'update-types'], list[st
         # Ignore package altogether
         return [{"operator": ">=", "version": "0"}], {}
 
-    versions = []
-    update_types = {}
+    versions: 'list[dict[Literal["operator", "version"], str]]' = []
+    update_types: "dict[Literal['version-update'], list[Literal['major', 'minor', 'patch']]]" = (  # pylint: disable=line-too-long
+        {}
+    )
 
     if "versions" in rules:
         for versions_entry in rules["versions"]:
@@ -374,7 +393,7 @@ def parse_ignore_rules(rules: "dict[Literal['versions', 'update-types'], list[st
                     "must be a single operator followed by a version number.\n"
                     f"Unparseable 'versions' value: {versions_entry!r}"
                 )
-            versions.append(match.groupdict())
+            versions.append(match.groupdict())  # type: ignore[arg-type]
 
     if "update-types" in rules:
         update_types["version-update"] = []
@@ -391,16 +410,128 @@ def parse_ignore_rules(rules: "dict[Literal['versions', 'update-types'], list[st
                     "'version-update:semver-patch'.\nUnparseable 'update-types' "
                     f"value: {update_type_entry!r}"
                 )
-            update_types["version-update"].append(match.group("semver_part"))
+            update_types["version-update"].append(match.group("semver_part"))  # type: ignore[arg-type]  # pylint: disable=line-too-long
 
     return versions, update_types
+
+
+def _ignore_version_rules(
+    latest: list[str],
+    version_rules: "list[dict[Literal['operator', 'version'], str]]",
+) -> bool:
+    """Determine whether to ignore package based on `versions` input."""
+    operators_mapping = {
+        ">": operator.gt,
+        "<": operator.lt,
+        "<=": operator.le,
+        ">=": operator.ge,
+        "==": operator.eq,
+        "!=": operator.ne,
+    }
+
+    decision_version_rules = []
+    for version_rule in version_rules:
+        decision_version_rule = False
+        split_version_rule = version_rule.get("version", "").split(".")
+
+        if version_rule.get("operator", "") in operators_mapping:
+            # Extend version rule with zeros if needed
+            if len(split_version_rule) < len(latest):
+                split_version_rule.extend(
+                    ["0"] * (len(latest) - len(split_version_rule))
+                )
+            if len(split_version_rule) != len(latest):
+                raise CICDException("Zero-filling failed for version.")
+
+            any_all_logic = (
+                all
+                if "=" in version_rule["operator"] and version_rule["operator"] != "!="
+                else any
+            )
+            if any_all_logic(
+                operators_mapping[version_rule["operator"]](
+                    latest_part, version_rule_part
+                )
+                for latest_part, version_rule_part in zip(latest, split_version_rule)
+            ):
+                decision_version_rule = True
+        elif "~=" == version_rule.get("operator", ""):
+            if len(split_version_rule) == 1:
+                raise InputError(
+                    "Ignore option value error. For the 'versions' config key, when "
+                    "using the '~=' operator more than a single version part MUST be "
+                    "specified. E.g., '~=2' is disallowed, instead use '~=2.0' or "
+                    "similar."
+                )
+
+            if all(
+                latest_part >= version_rule_part
+                for latest_part, version_rule_part in zip(latest, split_version_rule)
+            ) and all(
+                latest_part == version_rule_part
+                for latest_part, version_rule_part in zip(
+                    latest[:-1], split_version_rule[:-1]
+                )
+            ):
+                decision_version_rule = True
+        elif version_rule.get("operator", ""):
+            # Should not be possible to reach if using `parse_ignore_rules()`
+            # But for completion, and understanding, this is still kept.
+            raise InputParserError(
+                "Unknown ignore options 'versions' config value operator: "
+                f"{version_rule['operator']}"
+            )
+        decision_version_rules.append(decision_version_rule)
+
+    # If ALL version rules AND'ed together are True, ignore the version.
+    return bool(decision_version_rules and all(decision_version_rules))
+
+
+def _ignore_semver_rules(
+    current: list[str],
+    latest: list[str],
+    semver_rules: "dict[Literal['version-update'], list[Literal['major', 'minor', 'patch']]]",  # pylint: disable=line-too-long
+) -> bool:
+    """If ANY of the semver rules are True, ignore the version."""
+    if any(
+        _ not in ["major", "minor", "patch"] for _ in semver_rules["version-update"]
+    ):
+        raise InputParserError(
+            f"Only valid values for 'version-update' are 'major', 'minor', and "
+            f"'patch' (you gave {semver_rules['version-update']!r})."
+        )
+
+    if "major" in semver_rules["version-update"]:
+        if latest[0] != current[0]:
+            return True
+
+    elif "minor" in semver_rules["version-update"]:
+        if (
+            len(latest) >= 2
+            and len(current) >= 2
+            and latest[1] > current[1]
+            and latest[0] == current[0]
+        ):
+            return True
+
+    elif "patch" in semver_rules["version-update"]:
+        if (
+            len(latest) >= 3
+            and len(current) >= 3
+            and latest[2] > current[2]
+            and latest[0] == current[0]
+            and latest[1] == current[1]
+        ):
+            return True
+
+    return False
 
 
 def ignore_version(
     current: list[str],
     latest: list[str],
     version_rules: "list[dict[Literal['operator', 'version'], str]]",
-    semver_rules: "dict[Literal['version-update'], list[Literal['major', 'minor', 'patch']]]",
+    semver_rules: "dict[Literal['version-update'], list[Literal['major', 'minor', 'patch']]]",  # pylint: disable=line-too-long
 ) -> bool:
     """Determine whether the latest version can be ignored.
 
@@ -419,86 +550,18 @@ def ignore_version(
     """
     # ignore all updates
     if not version_rules and not semver_rules:
-        # A package name has been specified without specific rules, ignore all updates for package.
+        # A package name has been specified without specific rules, ignore all updates
+        # for package.
         return True
 
-    # version
-    operators_mapping = {
-        ">": operator.gt,
-        "<": operator.lt,
-        "<=": operator.le,
-        ">=": operator.ge,
-        "==": operator.eq,
-        "!=": operator.ne,
-    }
-
-    decision_version_rules = []
-    for version_rule in version_rules:
-        decision_version_rule = False
-        split_version_rule = version_rule.get("version", "").split(".")
-
-        if version_rule.get("operator", "") in operators_mapping:
-            # Extend version rule with zeros if needed
-            if len(split_version_rule) < len(latest):
-                split_version_rule.extend(["0"] * (len(latest) - len(split_version_rule)))
-            assert len(split_version_rule) == len(latest)
-
-            any_all_logic = (
-                all
-                if "=" in version_rule["operator"] and version_rule["operator"] != "!="
-                else any
-            )
-            if any_all_logic(
-                operators_mapping[version_rule["operator"]](latest_part, version_rule_part)
-                for latest_part, version_rule_part in zip(latest, split_version_rule)
-            ):
-                decision_version_rule = True
-        elif "~=" == version_rule.get("operator", ""):
-            if len(split_version_rule) == 1:
-                raise InputError(
-                    "Ignore option value error. For the 'versions' config key, when using "
-                    "the '~=' operator more than a single version part MUST be specified. "
-                    "E.g., '~=2' is disallowed, instead use '~=2.0' or similar."
-                )
-
-            if all(
-                latest_part >= version_rule_part
-                for latest_part, version_rule_part in zip(latest, split_version_rule)
-            ) and all(
-                latest_part == version_rule_part
-                for latest_part, version_rule_part in zip(latest[:-1], split_version_rule[:-1])
-            ):
-                decision_version_rule = True
-        elif version_rule.get("operator", ""):
-            # Should not be possible to reach if using `parse_ignore_rules()`
-            # But for completion, and understanding, this is still kept.
-            raise InputParserError(
-                "Unknown ignore options 'versions' config value operator: "
-                f"{version_rule['operator']}"
-            )
-        decision_version_rules.append(decision_version_rule)
-
-    # If ALL version rules AND'ed together are True, ignore the version.
-    if decision_version_rules and all(decision_version_rules):
+    # version rules
+    if _ignore_version_rules(latest, version_rules):
         return True
 
-    # semver
-    # If ANY of the semver rules are True, ignore the version.
-    if "version-update" in semver_rules:
-        if any(_ not in ["major", "minor", "patch"] for _ in semver_rules["version-update"]):
-            raise InputParserError(
-                f"Only valid values for 'version-update' are 'major', 'minor', and "
-                f"'patch' (you gave {semver_rules['version-update']!r})."
-            )
-
-        if "major" in semver_rules["version-update"]:
-            if latest[0] != current[0]:
-                return True
-        elif "minor" in semver_rules["version-update"]:
-            if len(latest) >= 2 and len(current) >= 2 and latest[1] > current[1] and latest[0] == current[0]:
-                return True
-        elif "patch" in semver_rules["version-update"]:
-            if len(latest) >= 3 and len(current) >= 3 and latest[2] > current[2] and latest[0] == current[0] and latest[1] == current[1]:
-                return True
+    # semver rules
+    if "version-update" in semver_rules and _ignore_semver_rules(
+        current, latest, semver_rules
+    ):
+        return True
 
     return False

--- a/docs/api_reference/exceptions.md
+++ b/docs/api_reference/exceptions.md
@@ -1,0 +1,3 @@
+# exceptions
+
+::: ci_cd.exceptions

--- a/docs/workflows/ci_check_pyproject_dependencies.md
+++ b/docs/workflows/ci_check_pyproject_dependencies.md
@@ -10,6 +10,42 @@ The reason for having this workflow and not using [Dependabot](https://github.co
     If a PAT is not passed through for the `PAT` secret and `GITHUB_TOKEN` is used, beware that any other CI/CD jobs that run for, e.g., pull request events, may not run since `GITHUB_TOKEN`-generated PRs are designed to not start more workflows to avoid escalation.
     Hence, if it is important to run CI/CD workflows for pull requests, consider passing a PAT as a secret to this workflow represented by the `PAT` secret.
 
+## Ignoring dependencies
+
+To ignore or configure how specific dependencies should be updated, the `ignore` input option can be utilized.
+This is done by specifying a line per dependency that contains ellipsis-separated (`...`) key/value-pairs of:
+
+| **Key** | **Description** |
+|:---:|:--- |
+| `dependency-name` | Ignore updates for dependencies with matching names, optionally using `*` to match zero or more characters. |
+| `versions` | Ignore specific versions or ranges of versions. Examples: `~=1.0.5`, `>= 1.0.5,<2`, `>=0.1.1`. |
+| `update-types` | Ignore types of updates, such as [SemVer](https://semver.org) `major`, `minor`, `patch` updates on version updates (for example: `version-update:semver-patch` will ignore patch updates). This can be combined with `dependency-name=*` to ignore particular `update-types` for all dependencies. |
+
+!!! note "Supported `update-types` values"
+    Currently, only `version-update:semver-major`, `version-update:semver-minor`, and `version-update:semver-patch` are supported options for `update-types`.
+
+The `ignore` option is essentially similar to [the `ignore` option of Dependabot](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#ignore).
+If `versions` and `update-types` are used together, they will both be respected jointly.
+
+Here is an example of different lines given as value for the `ignore` option that accomplishes different things:
+
+```yaml
+# ...
+jobs:
+  check-dependencies:
+    uses: SINTEF/ci-cd/.github/workflows/ci_check_pyproject_dependencies.yml@v2.0.0
+    with:
+      # ...
+      # For Sphinx, ignore all updates for/from version 4.5.0 and up / keep the minimum version for Sphinx at 4.5.0.
+      # For pydantic, ignore all patch updates
+      # For numpy, ignore any and all updates
+      ignore: |
+        dependency-name=Sphinx...versions=>=4.5.0
+        dependency-name=pydantic...update-types=version-update:semver-patch
+        dependency-name=numpy
+# ...
+```
+
 ## Expectations
 
 The repository contains the following:
@@ -28,6 +64,7 @@ The repository contains the following:
 | `pr_body_file` | Relative path to PR body file from the root of the repository.</br></br>Example: `'.github/utils/pr_body_deps_check.txt'`. | No | _Empty string_ | _string_ |
 | `fail_fast` | Whether the task to update dependencies should fail if any error occurs. | No | `false` | _boolean_ |
 | `pr_labels` | A comma separated list of strings of GitHub labels to use for the created PR. | No | _Empty string_ | _string_ |
+| `ignore` | Create ignore conditions for certain dependencies. A multi-line string of ignore rules, where each line is an ellipsis-separated (`...`) string of key/value-pairs. One line per dependency. This option is similar to [the `ignore` option of Dependabot](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#ignore). | No | _Empty string_ | _string_
 
 ## Secrets
 

--- a/tests/tasks/test_api_reference_docs.py
+++ b/tests/tasks/test_api_reference_docs.py
@@ -227,10 +227,9 @@ def test_special_options(tmp_path: "Path") -> None:
         another line
 """
     )
-    assert (
-        (api_reference_folder / "exceptions.md").read_text(encoding="utf8")
-        == "# exceptions\n\n::: ci_cd.exceptions\n"
-    )
+    assert (api_reference_folder / "exceptions.md").read_text(
+        encoding="utf8"
+    ) == "# exceptions\n\n::: ci_cd.exceptions\n"
 
     assert (api_reference_folder / "tasks" / ".pages").read_text(
         encoding="utf8"
@@ -352,7 +351,9 @@ def test_special_options_multiple_packages(tmp_path: "Path") -> None:
 """
     )
     assert (
-        (api_reference_folder / "ci_cd_again" / "exceptions.md").read_text(encoding="utf8")
+        (api_reference_folder / "ci_cd_again" / "exceptions.md").read_text(
+            encoding="utf8"
+        )
         == """# exceptions
 
 ::: ci_cd_again.exceptions
@@ -420,15 +421,27 @@ def test_larger_package(tmp_path: "Path") -> None:
     assert (
         api_reference_folder.exists()
     ), f"Parent content: {os.listdir(api_reference_folder.parent)}"
-    assert {".pages", "main.md", "utils.md", "tasks", "exceptions.md", "module", "second_module"} == set(
-        os.listdir(api_reference_folder)
-    )
+    assert {
+        ".pages",
+        "main.md",
+        "utils.md",
+        "tasks",
+        "exceptions.md",
+        "module",
+        "second_module",
+    } == set(os.listdir(api_reference_folder))
     for module_dir in [
         api_reference_folder / _.relative_to(package_dir) for _ in new_submodules
     ]:
         extra_dir_content = {"submodule"} if module_dir.name == "module" else set()
         assert module_dir.exists(), f"Parent content: {os.listdir(module_dir.parent)}"
-        assert {".pages", "main.md", "utils.md", "tasks", "exceptions.md"} | extra_dir_content == set(
+        assert {
+            ".pages",
+            "main.md",
+            "utils.md",
+            "tasks",
+            "exceptions.md",
+        } | extra_dir_content == set(
             os.listdir(module_dir)
         ), f"module_dir: {module_dir.relative_to(api_reference_folder)}"
 

--- a/tests/tasks/test_api_reference_docs.py
+++ b/tests/tasks/test_api_reference_docs.py
@@ -37,7 +37,7 @@ def test_default_run(tmp_path: "Path") -> None:
     assert (
         api_reference_folder.exists()
     ), f"Parent content: {os.listdir(api_reference_folder.parent)}"
-    assert {".pages", "main.md", "utils.md", "tasks"} == set(
+    assert {".pages", "main.md", "utils.md", "tasks", "exceptions.md"} == set(
         os.listdir(api_reference_folder)
     )
     assert {
@@ -57,6 +57,9 @@ def test_default_run(tmp_path: "Path") -> None:
     assert (api_reference_folder / "utils.md").read_text(
         encoding="utf8"
     ) == "# utils\n\n::: ci_cd.utils\n"
+    assert (api_reference_folder / "exceptions.md").read_text(
+        encoding="utf8"
+    ) == "# exceptions\n\n::: ci_cd.exceptions\n"
 
     assert (api_reference_folder / "tasks" / ".pages").read_text(
         encoding="utf8"
@@ -108,7 +111,7 @@ def test_nested_package(tmp_path: "Path") -> None:
     assert (
         api_reference_folder.exists()
     ), f"Parent content: {os.listdir(api_reference_folder.parent)}"
-    assert {".pages", "main.md", "utils.md", "tasks"} == set(
+    assert {".pages", "main.md", "utils.md", "tasks", "exceptions.md"} == set(
         os.listdir(api_reference_folder)
     )
     assert {
@@ -128,6 +131,9 @@ def test_nested_package(tmp_path: "Path") -> None:
     assert (api_reference_folder / "utils.md").read_text(
         encoding="utf8"
     ) == "# utils\n\n::: src.ci_cd.ci_cd.utils\n"
+    assert (api_reference_folder / "exceptions.md").read_text(
+        encoding="utf8"
+    ) == "# exceptions\n\n::: src.ci_cd.ci_cd.exceptions\n"
 
     assert (api_reference_folder / "tasks" / ".pages").read_text(
         encoding="utf8"
@@ -185,7 +191,7 @@ def test_special_options(tmp_path: "Path") -> None:
     assert (
         api_reference_folder.exists()
     ), f"Parent content: {os.listdir(api_reference_folder.parent)}"
-    assert {".pages", "main.md", "utils.md", "tasks"} == set(
+    assert {".pages", "main.md", "utils.md", "tasks", "exceptions.md"} == set(
         os.listdir(api_reference_folder)
     )
     assert {
@@ -220,6 +226,10 @@ def test_special_options(tmp_path: "Path") -> None:
         multi-line-thing
         another line
 """
+    )
+    assert (
+        (api_reference_folder / "exceptions.md").read_text(encoding="utf8")
+        == "# exceptions\n\n::: ci_cd.exceptions\n"
     )
 
     assert (api_reference_folder / "tasks" / ".pages").read_text(
@@ -284,7 +294,7 @@ def test_special_options_multiple_packages(tmp_path: "Path") -> None:
     ), f"Parent content: {os.listdir(api_reference_folder.parent)}"
     assert {".pages", "ci_cd", "ci_cd_again"} == set(os.listdir(api_reference_folder))
     for package_dir in [api_reference_folder / _.name for _ in package_dirs]:
-        assert {".pages", "main.md", "utils.md", "tasks"} == set(
+        assert {".pages", "main.md", "utils.md", "tasks", "exceptions.md"} == set(
             os.listdir(package_dir)
         )
         assert {
@@ -316,6 +326,13 @@ def test_special_options_multiple_packages(tmp_path: "Path") -> None:
 """
     )
     assert (
+        (api_reference_folder / "ci_cd" / "exceptions.md").read_text(encoding="utf8")
+        == """# exceptions
+
+::: ci_cd.exceptions
+"""
+    )
+    assert (
         (api_reference_folder / "ci_cd_again" / "main.md").read_text(encoding="utf8")
         == """# main
 
@@ -332,6 +349,13 @@ def test_special_options_multiple_packages(tmp_path: "Path") -> None:
       my_special_option: |
         multi-line-thing
         another line
+"""
+    )
+    assert (
+        (api_reference_folder / "ci_cd_again" / "exceptions.md").read_text(encoding="utf8")
+        == """# exceptions
+
+::: ci_cd_again.exceptions
 """
     )
 
@@ -396,7 +420,7 @@ def test_larger_package(tmp_path: "Path") -> None:
     assert (
         api_reference_folder.exists()
     ), f"Parent content: {os.listdir(api_reference_folder.parent)}"
-    assert {".pages", "main.md", "utils.md", "tasks", "module", "second_module"} == set(
+    assert {".pages", "main.md", "utils.md", "tasks", "exceptions.md", "module", "second_module"} == set(
         os.listdir(api_reference_folder)
     )
     for module_dir in [
@@ -404,7 +428,7 @@ def test_larger_package(tmp_path: "Path") -> None:
     ]:
         extra_dir_content = {"submodule"} if module_dir.name == "module" else set()
         assert module_dir.exists(), f"Parent content: {os.listdir(module_dir.parent)}"
-        assert {".pages", "main.md", "utils.md", "tasks"} | extra_dir_content == set(
+        assert {".pages", "main.md", "utils.md", "tasks", "exceptions.md"} | extra_dir_content == set(
             os.listdir(module_dir)
         ), f"module_dir: {module_dir.relative_to(api_reference_folder)}"
 
@@ -417,6 +441,9 @@ def test_larger_package(tmp_path: "Path") -> None:
     assert (api_reference_folder / "utils.md").read_text(
         encoding="utf8"
     ) == "# utils\n\n::: ci_cd.utils\n"
+    assert (api_reference_folder / "exceptions.md").read_text(
+        encoding="utf8"
+    ) == "# exceptions\n\n::: ci_cd.exceptions\n"
 
     assert (api_reference_folder / "tasks" / ".pages").read_text(
         encoding="utf8"
@@ -453,6 +480,11 @@ def test_larger_package(tmp_path: "Path") -> None:
         assert (module_dir / "utils.md").read_text(
             encoding="utf8"
         ) == f"# utils\n\n::: {py_path}.utils\n", (
+            f"module_dir: {module_dir.relative_to(api_reference_folder)}"
+        )
+        assert (module_dir / "exceptions.md").read_text(
+            encoding="utf8"
+        ) == f"# exceptions\n\n::: {py_path}.exceptions\n", (
             f"module_dir: {module_dir.relative_to(api_reference_folder)}"
         )
 
@@ -533,6 +565,7 @@ def test_larger_multi_packages(tmp_path: "Path") -> None:
             "main.md",
             "utils.md",
             "tasks",
+            "exceptions.md",
             "module",
             "second_module",
         } == set(
@@ -548,6 +581,7 @@ def test_larger_multi_packages(tmp_path: "Path") -> None:
                 "main.md",
                 "utils.md",
                 "tasks",
+                "exceptions.md",
             } | extra_dir_content == set(
                 os.listdir(module_dir)
             ), f"module_dir: {module_dir.relative_to(api_reference_folder)}"
@@ -567,6 +601,9 @@ def test_larger_multi_packages(tmp_path: "Path") -> None:
         assert (package_dir / "utils.md").read_text(
             encoding="utf8"
         ) == f"# utils\n\n::: {package_dir.name}.utils\n"
+        assert (package_dir / "exceptions.md").read_text(
+            encoding="utf8"
+        ) == f"# exceptions\n\n::: {package_dir.name}.exceptions\n"
 
         assert (package_dir / "tasks" / ".pages").read_text(
             encoding="utf8"
@@ -601,6 +638,11 @@ def test_larger_multi_packages(tmp_path: "Path") -> None:
             assert (module_dir / "utils.md").read_text(
                 encoding="utf8"
             ) == f"# utils\n\n::: {py_path}.utils\n", (
+                f"module_dir: {module_dir.relative_to(api_reference_folder)}"
+            )
+            assert (module_dir / "exceptions.md").read_text(
+                encoding="utf8"
+            ) == f"# exceptions\n\n::: {py_path}.exceptions\n", (
                 f"module_dir: {module_dir.relative_to(api_reference_folder)}"
             )
 

--- a/tests/tasks/test_update_deps.py
+++ b/tests/tasks/test_update_deps.py
@@ -1,4 +1,5 @@
 """Test `ci_cd.tasks.update_deps()`."""
+# pylint: disable=line-too-long,too-many-lines
 from typing import TYPE_CHECKING
 
 import pytest
@@ -165,17 +166,101 @@ pep_508 = [
 @pytest.mark.parametrize(
     argnames=("entries", "separator", "expected_outcome"),
     argvalues=[
-        (["dependency-name=test...versions=>2.2.2"], "...", {"test": {"versions": [">2.2.2"]}}),
-        (["dependency-name=test...versions=>2.2.2...update-types=version-update:semver-patch"], "...", {"test": {"versions": [">2.2.2"], "update-types": ["version-update:semver-patch"]}}),
-        (["dependency-name=test;versions=>2.2.2;update-types=version-update:semver-patch"], ";", {"test": {"versions": [">2.2.2"], "update-types": ["version-update:semver-patch"]}}),
-        (["dependency-name=test...versions=>2.2.2...update-types=version-update:semver-patch", "dependency-name=test...versions=<3"], "...", {"test": {"versions": [">2.2.2", "<3"], "update-types": ["version-update:semver-patch"]}}),
-        (["dependency-name=test;versions=>2.2.2;update-types=version-update:semver-patch", "dependency-name=test;versions=<3"], ";", {"test": {"versions": [">2.2.2", "<3"], "update-types": ["version-update:semver-patch"]}}),
-        (["dependency-name=test...versions=>2.2.2...update-types=version-update:semver-patch", "dependency-name=test...versions=<3...update-types=version-update:semver-major"], "...", {"test": {"versions": [">2.2.2", "<3"], "update-types": ["version-update:semver-patch", "version-update:semver-major"]}}),
-        (["dependency-name=test;versions=>2.2.2;update-types=version-update:semver-patch", "dependency-name=test;versions=<3;update-types=version-update:semver-major"], ";", {"test": {"versions": [">2.2.2", "<3"], "update-types": ["version-update:semver-patch", "version-update:semver-major"]}}),
+        (
+            ["dependency-name=test...versions=>2.2.2"],
+            "...",
+            {"test": {"versions": [">2.2.2"]}},
+        ),
+        (
+            [
+                "dependency-name=test...versions=>2.2.2...update-types=version-update:semver-patch"
+            ],
+            "...",
+            {
+                "test": {
+                    "versions": [">2.2.2"],
+                    "update-types": ["version-update:semver-patch"],
+                }
+            },
+        ),
+        (
+            [
+                "dependency-name=test;versions=>2.2.2;update-types=version-update:semver-patch"
+            ],
+            ";",
+            {
+                "test": {
+                    "versions": [">2.2.2"],
+                    "update-types": ["version-update:semver-patch"],
+                }
+            },
+        ),
+        (
+            [
+                "dependency-name=test...versions=>2.2.2...update-types=version-update:semver-patch",
+                "dependency-name=test...versions=<3",
+            ],
+            "...",
+            {
+                "test": {
+                    "versions": [">2.2.2", "<3"],
+                    "update-types": ["version-update:semver-patch"],
+                }
+            },
+        ),
+        (
+            [
+                "dependency-name=test;versions=>2.2.2;update-types=version-update:semver-patch",
+                "dependency-name=test;versions=<3",
+            ],
+            ";",
+            {
+                "test": {
+                    "versions": [">2.2.2", "<3"],
+                    "update-types": ["version-update:semver-patch"],
+                }
+            },
+        ),
+        (
+            [
+                "dependency-name=test...versions=>2.2.2...update-types=version-update:semver-patch",
+                "dependency-name=test...versions=<3...update-types=version-update:semver-major",
+            ],
+            "...",
+            {
+                "test": {
+                    "versions": [">2.2.2", "<3"],
+                    "update-types": [
+                        "version-update:semver-patch",
+                        "version-update:semver-major",
+                    ],
+                }
+            },
+        ),
+        (
+            [
+                "dependency-name=test;versions=>2.2.2;update-types=version-update:semver-patch",
+                "dependency-name=test;versions=<3;update-types=version-update:semver-major",
+            ],
+            ";",
+            {
+                "test": {
+                    "versions": [">2.2.2", "<3"],
+                    "update-types": [
+                        "version-update:semver-patch",
+                        "version-update:semver-major",
+                    ],
+                }
+            },
+        ),
         (["dependency-name=test"], "...", {"test": {}}),
     ],
 )
-def test_parse_ignore_entries(entries: list[str], separator: str, expected_outcome: 'dict[str, dict[Literal["dependency-name", "versions", "update-types"], str]]') -> None:
+def test_parse_ignore_entries(
+    entries: list[str],
+    separator: str,
+    expected_outcome: 'dict[str, dict[Literal["dependency-name", "versions", "update-types"], str]]',
+) -> None:
     """Check the `--ignore` option values are parsed as expected."""
     from ci_cd.tasks.update_deps import parse_ignore_entries
 
@@ -183,7 +268,9 @@ def test_parse_ignore_entries(entries: list[str], separator: str, expected_outco
         entries=entries,
         separator=separator,
     )
-    assert parsed_entries == expected_outcome, f"""Failed for:
+    assert (
+        parsed_entries == expected_outcome
+    ), f"""Failed for:
   entries={entries}
   separator={separator}
 
@@ -199,18 +286,53 @@ Instead, parse_ignore_entries() returned:
     argnames=("rules", "expected_outcome"),
     argvalues=[
         ({"versions": [">2.2.2"]}, ([{"operator": ">", "version": "2.2.2"}], {})),
-        ({"versions": [">2.2.2"], "update-types": ["version-update:semver-patch"]}, ([{"operator": ">", "version": "2.2.2"}], {"version-update": ["patch"]})),
-        ({"versions": [">2.2.2", "<3"], "update-types": ["version-update:semver-patch"]}, ([{"operator": ">", "version": "2.2.2"}, {"operator": "<", "version": "3"}], {"version-update": ["patch"]})),
-        ({"versions": [">2.2.2", "<3"], "update-types": ["version-update:semver-patch", "version-update:semver-major"]}, ([{"operator": ">", "version": "2.2.2"}, {"operator": "<", "version": "3"}], {"version-update": ["patch", "major"]})),
+        (
+            {"versions": [">2.2.2"], "update-types": ["version-update:semver-patch"]},
+            ([{"operator": ">", "version": "2.2.2"}], {"version-update": ["patch"]}),
+        ),
+        (
+            {
+                "versions": [">2.2.2", "<3"],
+                "update-types": ["version-update:semver-patch"],
+            },
+            (
+                [
+                    {"operator": ">", "version": "2.2.2"},
+                    {"operator": "<", "version": "3"},
+                ],
+                {"version-update": ["patch"]},
+            ),
+        ),
+        (
+            {
+                "versions": [">2.2.2", "<3"],
+                "update-types": [
+                    "version-update:semver-patch",
+                    "version-update:semver-major",
+                ],
+            },
+            (
+                [
+                    {"operator": ">", "version": "2.2.2"},
+                    {"operator": "<", "version": "3"},
+                ],
+                {"version-update": ["patch", "major"]},
+            ),
+        ),
         ({}, ([{"operator": ">=", "version": "0"}], {})),
     ],
 )
-def test_parse_ignore_rules(rules: 'dict[Literal["versions", "update-types"], list[str]]', expected_outcome: "tuple[list[dict[Literal['operator', 'version'], str]], dict[Literal['version-update'], list[Literal['major', 'minor', 'patch']]]]") -> None:
+def test_parse_ignore_rules(
+    rules: 'dict[Literal["versions", "update-types"], list[str]]',
+    expected_outcome: "tuple[list[dict[Literal['operator', 'version'], str]], dict[Literal['version-update'], list[Literal['major', 'minor', 'patch']]]]",
+) -> None:
     """Check a specific set of ignore rules is parsed as expected."""
     from ci_cd.tasks.update_deps import parse_ignore_rules
 
     parsed_rules = parse_ignore_rules(rules=rules)
-    assert parsed_rules == expected_outcome, f"""Failed for:
+    assert (
+        parsed_rules == expected_outcome
+    ), f"""Failed for:
   rules={rules}
 
 Expected outcome:
@@ -221,13 +343,15 @@ Instead, parse_ignore_rules() returned:
 """
 
 
-def _parametrize_ignore_version() -> "dict[str, tuple[str, str, list[dict[Literal['operator', 'version'], str]], dict[Literal['version-update'], list[Literal['major', 'minor', 'patch']]], bool]]":
+def _parametrize_ignore_version() -> (
+    "dict[str, tuple[str, str, list[dict[Literal['operator', 'version'], str]], dict[Literal['version-update'], list[Literal['major', 'minor', 'patch']]], bool]]"
+):
     """Utility function for `test_ignore_version()`.
 
     The parametrized inputs are created in this function in order to have more
     meaningful IDs in the runtime overview.
     """
-    test_cases = [
+    test_cases: "list[tuple[str, str, list[dict[Literal['operator', 'version'], str]], dict[Literal['version-update'], list[Literal['major', 'minor', 'patch']]], bool]]" = [
         ("1.1.1", "2.2.2", [{"operator": ">", "version": "2.2.2"}], {}, False),
         ("1.1.1", "2.2.2", [{"operator": ">", "version": "2.2"}], {}, True),
         ("1.1.1", "2.2.2", [{"operator": ">", "version": "2"}], {}, True),
@@ -259,89 +383,511 @@ def _parametrize_ignore_version() -> "dict[str, tuple[str, str, list[dict[Litera
         ("1.1.1", "2.2.1", [], {"version-update": ["patch"]}, False),
         ("1.1.1", "1.2.1", [], {"version-update": ["minor"]}, True),
         ("1.1.1", "1.1.2", [], {"version-update": ["patch"]}, True),
-        ("1.1.1", "2.2.2", [{"operator": ">", "version": "2.2.2"}], {"version-update": ["major"]}, True),
-        ("1.1.1", "2.2.2", [{"operator": ">", "version": "2.2.2"}], {"version-update": ["minor"]}, False),
-        ("1.1.1", "2.2.2", [{"operator": ">", "version": "2.2.2"}], {"version-update": ["patch"]}, False),
-        ("1.1.1", "2.2.2", [{"operator": ">", "version": "2.2"}], {"version-update": ["major"]}, True),
-        ("1.1.1", "2.2.2", [{"operator": ">", "version": "2.2"}], {"version-update": ["minor"]}, True),
-        ("1.1.1", "2.2.2", [{"operator": ">", "version": "2.2"}], {"version-update": ["patch"]}, True),
-        ("1.1.1", "2.2.2", [{"operator": ">", "version": "2"}], {"version-update": ["major"]}, True),
-        ("1.1.1", "2.2.2", [{"operator": ">", "version": "2"}], {"version-update": ["minor"]}, True),
-        ("1.1.1", "2.2.2", [{"operator": ">", "version": "2"}], {"version-update": ["patch"]}, True),
-        ("1.1.1", "2.2.2", [{"operator": ">=", "version": "2.2.2"}], {"version-update": ["major"]}, True),
-        ("1.1.1", "2.2.2", [{"operator": ">=", "version": "2.2.2"}], {"version-update": ["minor"]}, True),
-        ("1.1.1", "2.2.2", [{"operator": ">=", "version": "2.2.2"}], {"version-update": ["patch"]}, True),
-        ("1.1.1", "2.2.2", [{"operator": ">=", "version": "2.2"}], {"version-update": ["major"]}, True),
-        ("1.1.1", "2.2.2", [{"operator": ">=", "version": "2.2"}], {"version-update": ["minor"]}, True),
-        ("1.1.1", "2.2.2", [{"operator": ">=", "version": "2.2"}], {"version-update": ["patch"]}, True),
-        ("1.1.1", "2.2.2", [{"operator": ">=", "version": "2"}], {"version-update": ["major"]}, True),
-        ("1.1.1", "2.2.2", [{"operator": ">=", "version": "2"}], {"version-update": ["minor"]}, True),
-        ("1.1.1", "2.2.2", [{"operator": ">=", "version": "2"}], {"version-update": ["patch"]}, True),
-        ("1.1.1", "2.2.2", [{"operator": "<", "version": "2.2.2"}], {"version-update": ["major"]}, True),
-        ("1.1.1", "2.2.2", [{"operator": "<", "version": "2.2.2"}], {"version-update": ["minor"]}, False),
-        ("1.1.1", "2.2.2", [{"operator": "<", "version": "2.2.2"}], {"version-update": ["patch"]}, False),
-        ("1.1.1", "2.2.2", [{"operator": "<", "version": "2.2"}], {"version-update": ["major"]}, True),
-        ("1.1.1", "2.2.2", [{"operator": "<", "version": "2.2"}], {"version-update": ["minor"]}, False),
-        ("1.1.1", "2.2.2", [{"operator": "<", "version": "2.2"}], {"version-update": ["patch"]}, False),
-        ("1.1.1", "2.2.2", [{"operator": "<", "version": "2"}], {"version-update": ["major"]}, True),
-        ("1.1.1", "2.2.2", [{"operator": "<", "version": "2"}], {"version-update": ["minor"]}, False),
-        ("1.1.1", "2.2.2", [{"operator": "<", "version": "2"}], {"version-update": ["patch"]}, False),
-        ("1.1.1", "2.2.2", [{"operator": "<=", "version": "2.2.2"}], {"version-update": ["major"]}, True),
-        ("1.1.1", "2.2.2", [{"operator": "<=", "version": "2.2.2"}], {"version-update": ["minor"]}, True),
-        ("1.1.1", "2.2.2", [{"operator": "<=", "version": "2.2.2"}], {"version-update": ["patch"]}, True),
-        ("1.1.1", "2.2.2", [{"operator": "<=", "version": "2.2"}], {"version-update": ["major"]}, True),
-        ("1.1.1", "2.2.2", [{"operator": "<=", "version": "2.2"}], {"version-update": ["minor"]}, False),
-        ("1.1.1", "2.2.2", [{"operator": "<=", "version": "2.2"}], {"version-update": ["patch"]}, False),
-        ("1.1.1", "2.2.2", [{"operator": "<=", "version": "2"}], {"version-update": ["major"]}, True),
-        ("1.1.1", "2.2.2", [{"operator": "<=", "version": "2"}], {"version-update": ["minor"]}, False),
-        ("1.1.1", "2.2.2", [{"operator": "<=", "version": "2"}], {"version-update": ["patch"]}, False),
-        ("1.1.1", "2.2.2", [{"operator": "==", "version": "2.2.2"}], {"version-update": ["major"]}, True),
-        ("1.1.1", "2.2.2", [{"operator": "==", "version": "2.2.2"}], {"version-update": ["minor"]}, True),
-        ("1.1.1", "2.2.2", [{"operator": "==", "version": "2.2.2"}], {"version-update": ["patch"]}, True),
-        ("1.1.1", "2.2.2", [{"operator": "==", "version": "2.2"}], {"version-update": ["major"]}, True),
-        ("1.1.1", "2.2.2", [{"operator": "==", "version": "2.2"}], {"version-update": ["minor"]}, False),
-        ("1.1.1", "2.2.2", [{"operator": "==", "version": "2.2"}], {"version-update": ["patch"]}, False),
-        ("1.1.1", "2.2.2", [{"operator": "==", "version": "2"}], {"version-update": ["major"]}, True),
-        ("1.1.1", "2.2.2", [{"operator": "==", "version": "2"}], {"version-update": ["minor"]}, False),
-        ("1.1.1", "2.2.2", [{"operator": "==", "version": "2"}], {"version-update": ["patch"]}, False),
-        ("1.1.1", "2.2.2", [{"operator": "!=", "version": "2.2.2"}], {"version-update": ["major"]}, True),
-        ("1.1.1", "2.2.2", [{"operator": "!=", "version": "2.2.2"}], {"version-update": ["minor"]}, False),
-        ("1.1.1", "2.2.2", [{"operator": "!=", "version": "2.2.2"}], {"version-update": ["patch"]}, False),
-        ("1.1.1", "2.2.2", [{"operator": "!=", "version": "2.2"}], {"version-update": ["major"]}, True),
-        ("1.1.1", "2.2.2", [{"operator": "!=", "version": "2.2"}], {"version-update": ["minor"]}, True),
-        ("1.1.1", "2.2.2", [{"operator": "!=", "version": "2.2"}], {"version-update": ["patch"]}, True),
-        ("1.1.1", "2.2.2", [{"operator": "!=", "version": "2"}], {"version-update": ["major"]}, True),
-        ("1.1.1", "2.2.2", [{"operator": "!=", "version": "2"}], {"version-update": ["minor"]}, True),
-        ("1.1.1", "2.2.2", [{"operator": "!=", "version": "2"}], {"version-update": ["patch"]}, True),
-        ("1.1.1", "2.2.2", [{"operator": "~=", "version": "2.2.2"}], {"version-update": ["major"]}, True),
-        ("1.1.1", "2.2.2", [{"operator": "~=", "version": "2.2.2"}], {"version-update": ["minor"]}, True),
-        ("1.1.1", "2.2.2", [{"operator": "~=", "version": "2.2.2"}], {"version-update": ["patch"]}, True),
-        ("1.1.1", "2.2.2", [{"operator": "~=", "version": "2.2"}], {"version-update": ["major"]}, True),
-        ("1.1.1", "2.2.2", [{"operator": "~=", "version": "2.2"}], {"version-update": ["minor"]}, True),
-        ("1.1.1", "2.2.2", [{"operator": "~=", "version": "2.2"}], {"version-update": ["patch"]}, True),
-        ("1.1.1", "1.1.2", [{"operator": "~=", "version": "1.1"}], {"version-update": ["major"]}, True),
-        ("1.1.1", "1.1.2", [{"operator": "~=", "version": "1.1"}], {"version-update": ["minor"]}, True),
-        ("1.1.1", "1.1.2", [{"operator": "~=", "version": "1.1"}], {"version-update": ["patch"]}, True),
-        ("1.1.1", "1.1.2", [{"operator": "~=", "version": "1.0"}], {"version-update": ["major"]}, True),
-        ("1.1.1", "1.1.2", [{"operator": "~=", "version": "1.0"}], {"version-update": ["minor"]}, True),
-        ("1.1.1", "1.1.2", [{"operator": "~=", "version": "1.0"}], {"version-update": ["patch"]}, True),
-        ("1.1.1", "1.1.2", [{"operator": "~=", "version": "1.2"}], {"version-update": ["major"]}, False),
-        ("1.1.1", "1.1.2", [{"operator": "~=", "version": "1.2"}], {"version-update": ["minor"]}, False),
-        ("1.1.1", "1.1.2", [{"operator": "~=", "version": "1.2"}], {"version-update": ["patch"]}, True),
+        (
+            "1.1.1",
+            "2.2.2",
+            [{"operator": ">", "version": "2.2.2"}],
+            {"version-update": ["major"]},
+            True,
+        ),
+        (
+            "1.1.1",
+            "2.2.2",
+            [{"operator": ">", "version": "2.2.2"}],
+            {"version-update": ["minor"]},
+            False,
+        ),
+        (
+            "1.1.1",
+            "2.2.2",
+            [{"operator": ">", "version": "2.2.2"}],
+            {"version-update": ["patch"]},
+            False,
+        ),
+        (
+            "1.1.1",
+            "2.2.2",
+            [{"operator": ">", "version": "2.2"}],
+            {"version-update": ["major"]},
+            True,
+        ),
+        (
+            "1.1.1",
+            "2.2.2",
+            [{"operator": ">", "version": "2.2"}],
+            {"version-update": ["minor"]},
+            True,
+        ),
+        (
+            "1.1.1",
+            "2.2.2",
+            [{"operator": ">", "version": "2.2"}],
+            {"version-update": ["patch"]},
+            True,
+        ),
+        (
+            "1.1.1",
+            "2.2.2",
+            [{"operator": ">", "version": "2"}],
+            {"version-update": ["major"]},
+            True,
+        ),
+        (
+            "1.1.1",
+            "2.2.2",
+            [{"operator": ">", "version": "2"}],
+            {"version-update": ["minor"]},
+            True,
+        ),
+        (
+            "1.1.1",
+            "2.2.2",
+            [{"operator": ">", "version": "2"}],
+            {"version-update": ["patch"]},
+            True,
+        ),
+        (
+            "1.1.1",
+            "2.2.2",
+            [{"operator": ">=", "version": "2.2.2"}],
+            {"version-update": ["major"]},
+            True,
+        ),
+        (
+            "1.1.1",
+            "2.2.2",
+            [{"operator": ">=", "version": "2.2.2"}],
+            {"version-update": ["minor"]},
+            True,
+        ),
+        (
+            "1.1.1",
+            "2.2.2",
+            [{"operator": ">=", "version": "2.2.2"}],
+            {"version-update": ["patch"]},
+            True,
+        ),
+        (
+            "1.1.1",
+            "2.2.2",
+            [{"operator": ">=", "version": "2.2"}],
+            {"version-update": ["major"]},
+            True,
+        ),
+        (
+            "1.1.1",
+            "2.2.2",
+            [{"operator": ">=", "version": "2.2"}],
+            {"version-update": ["minor"]},
+            True,
+        ),
+        (
+            "1.1.1",
+            "2.2.2",
+            [{"operator": ">=", "version": "2.2"}],
+            {"version-update": ["patch"]},
+            True,
+        ),
+        (
+            "1.1.1",
+            "2.2.2",
+            [{"operator": ">=", "version": "2"}],
+            {"version-update": ["major"]},
+            True,
+        ),
+        (
+            "1.1.1",
+            "2.2.2",
+            [{"operator": ">=", "version": "2"}],
+            {"version-update": ["minor"]},
+            True,
+        ),
+        (
+            "1.1.1",
+            "2.2.2",
+            [{"operator": ">=", "version": "2"}],
+            {"version-update": ["patch"]},
+            True,
+        ),
+        (
+            "1.1.1",
+            "2.2.2",
+            [{"operator": "<", "version": "2.2.2"}],
+            {"version-update": ["major"]},
+            True,
+        ),
+        (
+            "1.1.1",
+            "2.2.2",
+            [{"operator": "<", "version": "2.2.2"}],
+            {"version-update": ["minor"]},
+            False,
+        ),
+        (
+            "1.1.1",
+            "2.2.2",
+            [{"operator": "<", "version": "2.2.2"}],
+            {"version-update": ["patch"]},
+            False,
+        ),
+        (
+            "1.1.1",
+            "2.2.2",
+            [{"operator": "<", "version": "2.2"}],
+            {"version-update": ["major"]},
+            True,
+        ),
+        (
+            "1.1.1",
+            "2.2.2",
+            [{"operator": "<", "version": "2.2"}],
+            {"version-update": ["minor"]},
+            False,
+        ),
+        (
+            "1.1.1",
+            "2.2.2",
+            [{"operator": "<", "version": "2.2"}],
+            {"version-update": ["patch"]},
+            False,
+        ),
+        (
+            "1.1.1",
+            "2.2.2",
+            [{"operator": "<", "version": "2"}],
+            {"version-update": ["major"]},
+            True,
+        ),
+        (
+            "1.1.1",
+            "2.2.2",
+            [{"operator": "<", "version": "2"}],
+            {"version-update": ["minor"]},
+            False,
+        ),
+        (
+            "1.1.1",
+            "2.2.2",
+            [{"operator": "<", "version": "2"}],
+            {"version-update": ["patch"]},
+            False,
+        ),
+        (
+            "1.1.1",
+            "2.2.2",
+            [{"operator": "<=", "version": "2.2.2"}],
+            {"version-update": ["major"]},
+            True,
+        ),
+        (
+            "1.1.1",
+            "2.2.2",
+            [{"operator": "<=", "version": "2.2.2"}],
+            {"version-update": ["minor"]},
+            True,
+        ),
+        (
+            "1.1.1",
+            "2.2.2",
+            [{"operator": "<=", "version": "2.2.2"}],
+            {"version-update": ["patch"]},
+            True,
+        ),
+        (
+            "1.1.1",
+            "2.2.2",
+            [{"operator": "<=", "version": "2.2"}],
+            {"version-update": ["major"]},
+            True,
+        ),
+        (
+            "1.1.1",
+            "2.2.2",
+            [{"operator": "<=", "version": "2.2"}],
+            {"version-update": ["minor"]},
+            False,
+        ),
+        (
+            "1.1.1",
+            "2.2.2",
+            [{"operator": "<=", "version": "2.2"}],
+            {"version-update": ["patch"]},
+            False,
+        ),
+        (
+            "1.1.1",
+            "2.2.2",
+            [{"operator": "<=", "version": "2"}],
+            {"version-update": ["major"]},
+            True,
+        ),
+        (
+            "1.1.1",
+            "2.2.2",
+            [{"operator": "<=", "version": "2"}],
+            {"version-update": ["minor"]},
+            False,
+        ),
+        (
+            "1.1.1",
+            "2.2.2",
+            [{"operator": "<=", "version": "2"}],
+            {"version-update": ["patch"]},
+            False,
+        ),
+        (
+            "1.1.1",
+            "2.2.2",
+            [{"operator": "==", "version": "2.2.2"}],
+            {"version-update": ["major"]},
+            True,
+        ),
+        (
+            "1.1.1",
+            "2.2.2",
+            [{"operator": "==", "version": "2.2.2"}],
+            {"version-update": ["minor"]},
+            True,
+        ),
+        (
+            "1.1.1",
+            "2.2.2",
+            [{"operator": "==", "version": "2.2.2"}],
+            {"version-update": ["patch"]},
+            True,
+        ),
+        (
+            "1.1.1",
+            "2.2.2",
+            [{"operator": "==", "version": "2.2"}],
+            {"version-update": ["major"]},
+            True,
+        ),
+        (
+            "1.1.1",
+            "2.2.2",
+            [{"operator": "==", "version": "2.2"}],
+            {"version-update": ["minor"]},
+            False,
+        ),
+        (
+            "1.1.1",
+            "2.2.2",
+            [{"operator": "==", "version": "2.2"}],
+            {"version-update": ["patch"]},
+            False,
+        ),
+        (
+            "1.1.1",
+            "2.2.2",
+            [{"operator": "==", "version": "2"}],
+            {"version-update": ["major"]},
+            True,
+        ),
+        (
+            "1.1.1",
+            "2.2.2",
+            [{"operator": "==", "version": "2"}],
+            {"version-update": ["minor"]},
+            False,
+        ),
+        (
+            "1.1.1",
+            "2.2.2",
+            [{"operator": "==", "version": "2"}],
+            {"version-update": ["patch"]},
+            False,
+        ),
+        (
+            "1.1.1",
+            "2.2.2",
+            [{"operator": "!=", "version": "2.2.2"}],
+            {"version-update": ["major"]},
+            True,
+        ),
+        (
+            "1.1.1",
+            "2.2.2",
+            [{"operator": "!=", "version": "2.2.2"}],
+            {"version-update": ["minor"]},
+            False,
+        ),
+        (
+            "1.1.1",
+            "2.2.2",
+            [{"operator": "!=", "version": "2.2.2"}],
+            {"version-update": ["patch"]},
+            False,
+        ),
+        (
+            "1.1.1",
+            "2.2.2",
+            [{"operator": "!=", "version": "2.2"}],
+            {"version-update": ["major"]},
+            True,
+        ),
+        (
+            "1.1.1",
+            "2.2.2",
+            [{"operator": "!=", "version": "2.2"}],
+            {"version-update": ["minor"]},
+            True,
+        ),
+        (
+            "1.1.1",
+            "2.2.2",
+            [{"operator": "!=", "version": "2.2"}],
+            {"version-update": ["patch"]},
+            True,
+        ),
+        (
+            "1.1.1",
+            "2.2.2",
+            [{"operator": "!=", "version": "2"}],
+            {"version-update": ["major"]},
+            True,
+        ),
+        (
+            "1.1.1",
+            "2.2.2",
+            [{"operator": "!=", "version": "2"}],
+            {"version-update": ["minor"]},
+            True,
+        ),
+        (
+            "1.1.1",
+            "2.2.2",
+            [{"operator": "!=", "version": "2"}],
+            {"version-update": ["patch"]},
+            True,
+        ),
+        (
+            "1.1.1",
+            "2.2.2",
+            [{"operator": "~=", "version": "2.2.2"}],
+            {"version-update": ["major"]},
+            True,
+        ),
+        (
+            "1.1.1",
+            "2.2.2",
+            [{"operator": "~=", "version": "2.2.2"}],
+            {"version-update": ["minor"]},
+            True,
+        ),
+        (
+            "1.1.1",
+            "2.2.2",
+            [{"operator": "~=", "version": "2.2.2"}],
+            {"version-update": ["patch"]},
+            True,
+        ),
+        (
+            "1.1.1",
+            "2.2.2",
+            [{"operator": "~=", "version": "2.2"}],
+            {"version-update": ["major"]},
+            True,
+        ),
+        (
+            "1.1.1",
+            "2.2.2",
+            [{"operator": "~=", "version": "2.2"}],
+            {"version-update": ["minor"]},
+            True,
+        ),
+        (
+            "1.1.1",
+            "2.2.2",
+            [{"operator": "~=", "version": "2.2"}],
+            {"version-update": ["patch"]},
+            True,
+        ),
+        (
+            "1.1.1",
+            "1.1.2",
+            [{"operator": "~=", "version": "1.1"}],
+            {"version-update": ["major"]},
+            True,
+        ),
+        (
+            "1.1.1",
+            "1.1.2",
+            [{"operator": "~=", "version": "1.1"}],
+            {"version-update": ["minor"]},
+            True,
+        ),
+        (
+            "1.1.1",
+            "1.1.2",
+            [{"operator": "~=", "version": "1.1"}],
+            {"version-update": ["patch"]},
+            True,
+        ),
+        (
+            "1.1.1",
+            "1.1.2",
+            [{"operator": "~=", "version": "1.0"}],
+            {"version-update": ["major"]},
+            True,
+        ),
+        (
+            "1.1.1",
+            "1.1.2",
+            [{"operator": "~=", "version": "1.0"}],
+            {"version-update": ["minor"]},
+            True,
+        ),
+        (
+            "1.1.1",
+            "1.1.2",
+            [{"operator": "~=", "version": "1.0"}],
+            {"version-update": ["patch"]},
+            True,
+        ),
+        (
+            "1.1.1",
+            "1.1.2",
+            [{"operator": "~=", "version": "1.2"}],
+            {"version-update": ["major"]},
+            False,
+        ),
+        (
+            "1.1.1",
+            "1.1.2",
+            [{"operator": "~=", "version": "1.2"}],
+            {"version-update": ["minor"]},
+            False,
+        ),
+        (
+            "1.1.1",
+            "1.1.2",
+            [{"operator": "~=", "version": "1.2"}],
+            {"version-update": ["patch"]},
+            True,
+        ),
         ("1.1.1", "1.1.2", [], {}, True),
     ]
-    res = {}
+    res: "dict[str, tuple[str, str, list[dict[Literal['operator', 'version'], str]], dict[Literal['version-update'], list[Literal['major', 'minor', 'patch']]], bool]]" = (
+        {}
+    )
     for test_case in test_cases:
         if test_case[2] and test_case[3]:
-            operator_version = ",".join(f"{_['operator']}{_['version']}" for _ in test_case[2])
+            operator_version = ",".join(
+                f"{_['operator']}{_['version']}" for _ in test_case[2]
+            )
             res[
                 f"{operator_version} + "
                 f"semver-{test_case[3]['version-update']}-latest={test_case[1]}"
             ] = test_case
         elif test_case[2]:
-            res[",".join(f"{_['operator']}{_['version']}" for _ in test_case[2])] = test_case
+            res[
+                ",".join(f"{_['operator']}{_['version']}" for _ in test_case[2])
+            ] = test_case
         elif test_case[3]:
-            res[f"semver-{test_case[3]['version-update']}-latest={test_case[1]}"] = test_case
+            res[
+                f"semver-{test_case[3]['version-update']}-latest={test_case[1]}"
+            ] = test_case
         else:
             res["no rules"] = test_case
     assert len(res) == len(test_cases)
@@ -363,12 +909,15 @@ def test_ignore_version(
     """Check the expected ignore rules are resolved correctly."""
     from ci_cd.tasks.update_deps import ignore_version
 
-    assert ignore_version(
-        current=current.split("."),
-        latest=latest.split("."),
-        version_rules=version_rules,
-        semver_rules=semver_rules,
-    ) == expected_outcome, f"""Failed for:
+    assert (
+        ignore_version(
+            current=current.split("."),
+            latest=latest.split("."),
+            version_rules=version_rules,
+            semver_rules=semver_rules,
+        )
+        == expected_outcome
+    ), f"""Failed for:
   current={current.split(".")}
   latest={latest.split(".")}
   version_rules={version_rules}
@@ -381,7 +930,7 @@ Instead, ignore_version() is {not expected_outcome}
 
 def test_ignore_version_fails() -> None:
     """Ensure `InputParserError` is raised for unknown ignore options."""
-    from ci_cd.exceptions import InputParserError, InputError
+    from ci_cd.exceptions import InputError, InputParserError
     from ci_cd.tasks.update_deps import ignore_version
 
     with pytest.raises(InputParserError, match=r"^Unknown ignore options 'versions'.*"):
@@ -392,15 +941,19 @@ def test_ignore_version_fails() -> None:
             semver_rules={},
         )
 
-    with pytest.raises(InputParserError, match=r"^Only valid values for 'version-update' are.*"):
+    with pytest.raises(
+        InputParserError, match=r"^Only valid values for 'version-update' are.*"
+    ):
         ignore_version(
             current="1.1.1".split("."),
             latest="2.2.2".split("."),
             version_rules=[],
-            semver_rules={"version-update": ["build"]},
+            semver_rules={"version-update": ["build"]},  # type: ignore[list-item]
         )
 
-    with pytest.raises(InputError, match=r"Ignore option value error. For the 'versions' config key.*"):
+    with pytest.raises(
+        InputError, match=r"Ignore option value error. For the 'versions' config key.*"
+    ):
         ignore_version(
             current="1.1.1".split("."),
             latest="2.2.2".split("."),
@@ -408,7 +961,8 @@ def test_ignore_version_fails() -> None:
             semver_rules={},
         )
 
-def test_ignore_rules_logic(tmp_path: "Path", caplog: pytest.LogCaptureFixture) -> None:
+
+def test_ignore_rules_logic(tmp_path: "Path") -> None:
     """Check the workflow of multiple interconnecting ignore rules are respected."""
     import re
 

--- a/tests/tasks/test_update_deps.py
+++ b/tests/tasks/test_update_deps.py
@@ -1,5 +1,7 @@
 """Test `ci_cd.tasks.update_deps()`."""
 # pylint: disable=line-too-long,too-many-lines
+from __future__ import annotations
+
 from typing import TYPE_CHECKING
 
 import pytest

--- a/tests/tasks/test_update_deps.py
+++ b/tests/tasks/test_update_deps.py
@@ -5,6 +5,7 @@ import pytest
 
 if TYPE_CHECKING:
     from pathlib import Path
+    from typing import Literal
 
 
 def test_update_deps(tmp_path: "Path", caplog: pytest.LogCaptureFixture) -> None:
@@ -157,5 +158,361 @@ pep_508 = [
                 "'name5 [fred,bar]' is pinned to a URL and will be skipped"
                 in caplog.text
             )
+        else:
+            pytest.fail(f"Unknown package in line: {line}")
+
+
+@pytest.mark.parametrize(
+    argnames=("entries", "separator", "expected_outcome"),
+    argvalues=[
+        (["dependency-name=test...versions=>2.2.2"], "...", {"test": {"versions": [">2.2.2"]}}),
+        (["dependency-name=test...versions=>2.2.2...update-types=version-update:semver-patch"], "...", {"test": {"versions": [">2.2.2"], "update-types": ["version-update:semver-patch"]}}),
+        (["dependency-name=test;versions=>2.2.2;update-types=version-update:semver-patch"], ";", {"test": {"versions": [">2.2.2"], "update-types": ["version-update:semver-patch"]}}),
+        (["dependency-name=test...versions=>2.2.2...update-types=version-update:semver-patch", "dependency-name=test...versions=<3"], "...", {"test": {"versions": [">2.2.2", "<3"], "update-types": ["version-update:semver-patch"]}}),
+        (["dependency-name=test;versions=>2.2.2;update-types=version-update:semver-patch", "dependency-name=test;versions=<3"], ";", {"test": {"versions": [">2.2.2", "<3"], "update-types": ["version-update:semver-patch"]}}),
+        (["dependency-name=test...versions=>2.2.2...update-types=version-update:semver-patch", "dependency-name=test...versions=<3...update-types=version-update:semver-major"], "...", {"test": {"versions": [">2.2.2", "<3"], "update-types": ["version-update:semver-patch", "version-update:semver-major"]}}),
+        (["dependency-name=test;versions=>2.2.2;update-types=version-update:semver-patch", "dependency-name=test;versions=<3;update-types=version-update:semver-major"], ";", {"test": {"versions": [">2.2.2", "<3"], "update-types": ["version-update:semver-patch", "version-update:semver-major"]}}),
+        (["dependency-name=test"], "...", {"test": {}}),
+    ],
+)
+def test_parse_ignore_entries(entries: list[str], separator: str, expected_outcome: 'dict[str, dict[Literal["dependency-name", "versions", "update-types"], str]]') -> None:
+    """Check the `--ignore` option values are parsed as expected."""
+    from ci_cd.tasks.update_deps import parse_ignore_entries
+
+    parsed_entries = parse_ignore_entries(
+        entries=entries,
+        separator=separator,
+    )
+    assert parsed_entries == expected_outcome, f"""Failed for:
+  entries={entries}
+  separator={separator}
+
+Expected outcome:
+{expected_outcome}
+
+Instead, parse_ignore_entries() returned:
+{parsed_entries}
+"""
+
+
+@pytest.mark.parametrize(
+    argnames=("rules", "expected_outcome"),
+    argvalues=[
+        ({"versions": [">2.2.2"]}, ([{"operator": ">", "version": "2.2.2"}], {})),
+        ({"versions": [">2.2.2"], "update-types": ["version-update:semver-patch"]}, ([{"operator": ">", "version": "2.2.2"}], {"version-update": ["patch"]})),
+        ({"versions": [">2.2.2", "<3"], "update-types": ["version-update:semver-patch"]}, ([{"operator": ">", "version": "2.2.2"}, {"operator": "<", "version": "3"}], {"version-update": ["patch"]})),
+        ({"versions": [">2.2.2", "<3"], "update-types": ["version-update:semver-patch", "version-update:semver-major"]}, ([{"operator": ">", "version": "2.2.2"}, {"operator": "<", "version": "3"}], {"version-update": ["patch", "major"]})),
+        ({}, ([{"operator": ">=", "version": "0"}], {})),
+    ],
+)
+def test_parse_ignore_rules(rules: 'dict[Literal["versions", "update-types"], list[str]]', expected_outcome: "tuple[list[dict[Literal['operator', 'version'], str]], dict[Literal['version-update'], list[Literal['major', 'minor', 'patch']]]]") -> None:
+    """Check a specific set of ignore rules is parsed as expected."""
+    from ci_cd.tasks.update_deps import parse_ignore_rules
+
+    parsed_rules = parse_ignore_rules(rules=rules)
+    assert parsed_rules == expected_outcome, f"""Failed for:
+  rules={rules}
+
+Expected outcome:
+{expected_outcome}
+
+Instead, parse_ignore_rules() returned:
+{parsed_rules}
+"""
+
+
+def _parametrize_ignore_version() -> "dict[str, tuple[str, str, list[dict[Literal['operator', 'version'], str]], dict[Literal['version-update'], list[Literal['major', 'minor', 'patch']]], bool]]":
+    """Utility function for `test_ignore_version()`.
+
+    The parametrized inputs are created in this function in order to have more
+    meaningful IDs in the runtime overview.
+    """
+    test_cases = [
+        ("1.1.1", "2.2.2", [{"operator": ">", "version": "2.2.2"}], {}, False),
+        ("1.1.1", "2.2.2", [{"operator": ">", "version": "2.2"}], {}, True),
+        ("1.1.1", "2.2.2", [{"operator": ">", "version": "2"}], {}, True),
+        ("1.1.1", "2.2.2", [{"operator": ">=", "version": "2.2.2"}], {}, True),
+        ("1.1.1", "2.2.2", [{"operator": ">=", "version": "2.2"}], {}, True),
+        ("1.1.1", "2.2.2", [{"operator": ">=", "version": "2"}], {}, True),
+        ("1.1.1", "2.2.2", [{"operator": "<", "version": "2.2.2"}], {}, False),
+        ("1.1.1", "2.2.2", [{"operator": "<", "version": "2.2"}], {}, False),
+        ("1.1.1", "2.2.2", [{"operator": "<", "version": "2"}], {}, False),
+        ("1.1.1", "2.2.2", [{"operator": "<=", "version": "2.2.2"}], {}, True),
+        ("1.1.1", "2.2.2", [{"operator": "<=", "version": "2.2"}], {}, False),
+        ("1.1.1", "2.2.2", [{"operator": "<=", "version": "2"}], {}, False),
+        ("1.1.1", "2.2.2", [{"operator": "==", "version": "2.2.2"}], {}, True),
+        ("1.1.1", "2.2.2", [{"operator": "==", "version": "2.2"}], {}, False),
+        ("1.1.1", "2.2.2", [{"operator": "==", "version": "2"}], {}, False),
+        ("1.1.1", "2.2.2", [{"operator": "!=", "version": "2.2.2"}], {}, False),
+        ("1.1.1", "2.2.2", [{"operator": "!=", "version": "2.2"}], {}, True),
+        ("1.1.1", "2.2.2", [{"operator": "!=", "version": "2"}], {}, True),
+        ("1.1.1", "2.2.2", [{"operator": "~=", "version": "2.2.2"}], {}, True),
+        ("1.1.1", "2.2.2", [{"operator": "~=", "version": "2.2"}], {}, True),
+        ("1.1.1", "1.1.2", [{"operator": "~=", "version": "1.1"}], {}, True),
+        ("1.1.1", "1.1.2", [{"operator": "~=", "version": "1.0"}], {}, True),
+        ("1.1.1", "1.1.2", [{"operator": "~=", "version": "1.2"}], {}, False),
+        ("1.1.1", "2.2.2", [], {"version-update": ["major"]}, True),
+        ("1.1.1", "2.2.2", [], {"version-update": ["minor"]}, False),
+        ("1.1.1", "2.2.2", [], {"version-update": ["patch"]}, False),
+        ("1.1.1", "1.2.2", [], {"version-update": ["major"]}, False),
+        ("1.1.1", "2.1.2", [], {"version-update": ["minor"]}, False),
+        ("1.1.1", "2.2.1", [], {"version-update": ["patch"]}, False),
+        ("1.1.1", "1.2.1", [], {"version-update": ["minor"]}, True),
+        ("1.1.1", "1.1.2", [], {"version-update": ["patch"]}, True),
+        ("1.1.1", "2.2.2", [{"operator": ">", "version": "2.2.2"}], {"version-update": ["major"]}, True),
+        ("1.1.1", "2.2.2", [{"operator": ">", "version": "2.2.2"}], {"version-update": ["minor"]}, False),
+        ("1.1.1", "2.2.2", [{"operator": ">", "version": "2.2.2"}], {"version-update": ["patch"]}, False),
+        ("1.1.1", "2.2.2", [{"operator": ">", "version": "2.2"}], {"version-update": ["major"]}, True),
+        ("1.1.1", "2.2.2", [{"operator": ">", "version": "2.2"}], {"version-update": ["minor"]}, True),
+        ("1.1.1", "2.2.2", [{"operator": ">", "version": "2.2"}], {"version-update": ["patch"]}, True),
+        ("1.1.1", "2.2.2", [{"operator": ">", "version": "2"}], {"version-update": ["major"]}, True),
+        ("1.1.1", "2.2.2", [{"operator": ">", "version": "2"}], {"version-update": ["minor"]}, True),
+        ("1.1.1", "2.2.2", [{"operator": ">", "version": "2"}], {"version-update": ["patch"]}, True),
+        ("1.1.1", "2.2.2", [{"operator": ">=", "version": "2.2.2"}], {"version-update": ["major"]}, True),
+        ("1.1.1", "2.2.2", [{"operator": ">=", "version": "2.2.2"}], {"version-update": ["minor"]}, True),
+        ("1.1.1", "2.2.2", [{"operator": ">=", "version": "2.2.2"}], {"version-update": ["patch"]}, True),
+        ("1.1.1", "2.2.2", [{"operator": ">=", "version": "2.2"}], {"version-update": ["major"]}, True),
+        ("1.1.1", "2.2.2", [{"operator": ">=", "version": "2.2"}], {"version-update": ["minor"]}, True),
+        ("1.1.1", "2.2.2", [{"operator": ">=", "version": "2.2"}], {"version-update": ["patch"]}, True),
+        ("1.1.1", "2.2.2", [{"operator": ">=", "version": "2"}], {"version-update": ["major"]}, True),
+        ("1.1.1", "2.2.2", [{"operator": ">=", "version": "2"}], {"version-update": ["minor"]}, True),
+        ("1.1.1", "2.2.2", [{"operator": ">=", "version": "2"}], {"version-update": ["patch"]}, True),
+        ("1.1.1", "2.2.2", [{"operator": "<", "version": "2.2.2"}], {"version-update": ["major"]}, True),
+        ("1.1.1", "2.2.2", [{"operator": "<", "version": "2.2.2"}], {"version-update": ["minor"]}, False),
+        ("1.1.1", "2.2.2", [{"operator": "<", "version": "2.2.2"}], {"version-update": ["patch"]}, False),
+        ("1.1.1", "2.2.2", [{"operator": "<", "version": "2.2"}], {"version-update": ["major"]}, True),
+        ("1.1.1", "2.2.2", [{"operator": "<", "version": "2.2"}], {"version-update": ["minor"]}, False),
+        ("1.1.1", "2.2.2", [{"operator": "<", "version": "2.2"}], {"version-update": ["patch"]}, False),
+        ("1.1.1", "2.2.2", [{"operator": "<", "version": "2"}], {"version-update": ["major"]}, True),
+        ("1.1.1", "2.2.2", [{"operator": "<", "version": "2"}], {"version-update": ["minor"]}, False),
+        ("1.1.1", "2.2.2", [{"operator": "<", "version": "2"}], {"version-update": ["patch"]}, False),
+        ("1.1.1", "2.2.2", [{"operator": "<=", "version": "2.2.2"}], {"version-update": ["major"]}, True),
+        ("1.1.1", "2.2.2", [{"operator": "<=", "version": "2.2.2"}], {"version-update": ["minor"]}, True),
+        ("1.1.1", "2.2.2", [{"operator": "<=", "version": "2.2.2"}], {"version-update": ["patch"]}, True),
+        ("1.1.1", "2.2.2", [{"operator": "<=", "version": "2.2"}], {"version-update": ["major"]}, True),
+        ("1.1.1", "2.2.2", [{"operator": "<=", "version": "2.2"}], {"version-update": ["minor"]}, False),
+        ("1.1.1", "2.2.2", [{"operator": "<=", "version": "2.2"}], {"version-update": ["patch"]}, False),
+        ("1.1.1", "2.2.2", [{"operator": "<=", "version": "2"}], {"version-update": ["major"]}, True),
+        ("1.1.1", "2.2.2", [{"operator": "<=", "version": "2"}], {"version-update": ["minor"]}, False),
+        ("1.1.1", "2.2.2", [{"operator": "<=", "version": "2"}], {"version-update": ["patch"]}, False),
+        ("1.1.1", "2.2.2", [{"operator": "==", "version": "2.2.2"}], {"version-update": ["major"]}, True),
+        ("1.1.1", "2.2.2", [{"operator": "==", "version": "2.2.2"}], {"version-update": ["minor"]}, True),
+        ("1.1.1", "2.2.2", [{"operator": "==", "version": "2.2.2"}], {"version-update": ["patch"]}, True),
+        ("1.1.1", "2.2.2", [{"operator": "==", "version": "2.2"}], {"version-update": ["major"]}, True),
+        ("1.1.1", "2.2.2", [{"operator": "==", "version": "2.2"}], {"version-update": ["minor"]}, False),
+        ("1.1.1", "2.2.2", [{"operator": "==", "version": "2.2"}], {"version-update": ["patch"]}, False),
+        ("1.1.1", "2.2.2", [{"operator": "==", "version": "2"}], {"version-update": ["major"]}, True),
+        ("1.1.1", "2.2.2", [{"operator": "==", "version": "2"}], {"version-update": ["minor"]}, False),
+        ("1.1.1", "2.2.2", [{"operator": "==", "version": "2"}], {"version-update": ["patch"]}, False),
+        ("1.1.1", "2.2.2", [{"operator": "!=", "version": "2.2.2"}], {"version-update": ["major"]}, True),
+        ("1.1.1", "2.2.2", [{"operator": "!=", "version": "2.2.2"}], {"version-update": ["minor"]}, False),
+        ("1.1.1", "2.2.2", [{"operator": "!=", "version": "2.2.2"}], {"version-update": ["patch"]}, False),
+        ("1.1.1", "2.2.2", [{"operator": "!=", "version": "2.2"}], {"version-update": ["major"]}, True),
+        ("1.1.1", "2.2.2", [{"operator": "!=", "version": "2.2"}], {"version-update": ["minor"]}, True),
+        ("1.1.1", "2.2.2", [{"operator": "!=", "version": "2.2"}], {"version-update": ["patch"]}, True),
+        ("1.1.1", "2.2.2", [{"operator": "!=", "version": "2"}], {"version-update": ["major"]}, True),
+        ("1.1.1", "2.2.2", [{"operator": "!=", "version": "2"}], {"version-update": ["minor"]}, True),
+        ("1.1.1", "2.2.2", [{"operator": "!=", "version": "2"}], {"version-update": ["patch"]}, True),
+        ("1.1.1", "2.2.2", [{"operator": "~=", "version": "2.2.2"}], {"version-update": ["major"]}, True),
+        ("1.1.1", "2.2.2", [{"operator": "~=", "version": "2.2.2"}], {"version-update": ["minor"]}, True),
+        ("1.1.1", "2.2.2", [{"operator": "~=", "version": "2.2.2"}], {"version-update": ["patch"]}, True),
+        ("1.1.1", "2.2.2", [{"operator": "~=", "version": "2.2"}], {"version-update": ["major"]}, True),
+        ("1.1.1", "2.2.2", [{"operator": "~=", "version": "2.2"}], {"version-update": ["minor"]}, True),
+        ("1.1.1", "2.2.2", [{"operator": "~=", "version": "2.2"}], {"version-update": ["patch"]}, True),
+        ("1.1.1", "1.1.2", [{"operator": "~=", "version": "1.1"}], {"version-update": ["major"]}, True),
+        ("1.1.1", "1.1.2", [{"operator": "~=", "version": "1.1"}], {"version-update": ["minor"]}, True),
+        ("1.1.1", "1.1.2", [{"operator": "~=", "version": "1.1"}], {"version-update": ["patch"]}, True),
+        ("1.1.1", "1.1.2", [{"operator": "~=", "version": "1.0"}], {"version-update": ["major"]}, True),
+        ("1.1.1", "1.1.2", [{"operator": "~=", "version": "1.0"}], {"version-update": ["minor"]}, True),
+        ("1.1.1", "1.1.2", [{"operator": "~=", "version": "1.0"}], {"version-update": ["patch"]}, True),
+        ("1.1.1", "1.1.2", [{"operator": "~=", "version": "1.2"}], {"version-update": ["major"]}, False),
+        ("1.1.1", "1.1.2", [{"operator": "~=", "version": "1.2"}], {"version-update": ["minor"]}, False),
+        ("1.1.1", "1.1.2", [{"operator": "~=", "version": "1.2"}], {"version-update": ["patch"]}, True),
+        ("1.1.1", "1.1.2", [], {}, True),
+    ]
+    res = {}
+    for test_case in test_cases:
+        if test_case[2] and test_case[3]:
+            operator_version = ",".join(f"{_['operator']}{_['version']}" for _ in test_case[2])
+            res[
+                f"{operator_version} + "
+                f"semver-{test_case[3]['version-update']}-latest={test_case[1]}"
+            ] = test_case
+        elif test_case[2]:
+            res[",".join(f"{_['operator']}{_['version']}" for _ in test_case[2])] = test_case
+        elif test_case[3]:
+            res[f"semver-{test_case[3]['version-update']}-latest={test_case[1]}"] = test_case
+        else:
+            res["no rules"] = test_case
+    assert len(res) == len(test_cases)
+    return res
+
+
+@pytest.mark.parametrize(
+    argnames=("current", "latest", "version_rules", "semver_rules", "expected_outcome"),
+    argvalues=list(_parametrize_ignore_version().values()),
+    ids=list(_parametrize_ignore_version()),
+)
+def test_ignore_version(
+    current: str,
+    latest: str,
+    version_rules: "list[dict[Literal['operator', 'version'], str]]",
+    semver_rules: "dict[Literal['version-update'], list[Literal['major', 'minor', 'patch']]]",
+    expected_outcome: bool,
+) -> None:
+    """Check the expected ignore rules are resolved correctly."""
+    from ci_cd.tasks.update_deps import ignore_version
+
+    assert ignore_version(
+        current=current.split("."),
+        latest=latest.split("."),
+        version_rules=version_rules,
+        semver_rules=semver_rules,
+    ) == expected_outcome, f"""Failed for:
+  current={current.split(".")}
+  latest={latest.split(".")}
+  version_rules={version_rules}
+  semver_rules={semver_rules}
+
+Expected outcome: {expected_outcome}
+Instead, ignore_version() is {not expected_outcome}
+"""
+
+
+def test_ignore_version_fails() -> None:
+    """Ensure `InputParserError` is raised for unknown ignore options."""
+    from ci_cd.exceptions import InputParserError, InputError
+    from ci_cd.tasks.update_deps import ignore_version
+
+    with pytest.raises(InputParserError, match=r"^Unknown ignore options 'versions'.*"):
+        ignore_version(
+            current="1.1.1".split("."),
+            latest="2.2.2".split("."),
+            version_rules=[{"operator": "===", "version": "2.2.2"}],
+            semver_rules={},
+        )
+
+    with pytest.raises(InputParserError, match=r"^Only valid values for 'version-update' are.*"):
+        ignore_version(
+            current="1.1.1".split("."),
+            latest="2.2.2".split("."),
+            version_rules=[],
+            semver_rules={"version-update": ["build"]},
+        )
+
+    with pytest.raises(InputError, match=r"Ignore option value error. For the 'versions' config key.*"):
+        ignore_version(
+            current="1.1.1".split("."),
+            latest="2.2.2".split("."),
+            version_rules=[{"operator": "~=", "version": "2"}],
+            semver_rules={},
+        )
+
+def test_ignore_rules_logic(tmp_path: "Path", caplog: pytest.LogCaptureFixture) -> None:
+    """Check the workflow of multiple interconnecting ignore rules are respected."""
+    import re
+
+    import tomlkit
+    from invoke import MockContext
+
+    from ci_cd.tasks import update_deps
+
+    original_dependencies = {
+        "invoke": "1.7",
+        "tomlkit": "0.11.4",
+        "mike": "1.1",
+        "pytest": "7.1",
+        "pytest-cov": "3.0",
+        "pre-commit": "2.20",
+        "pylint": "2.13",
+    }
+
+    pyproject_file = tmp_path / "pyproject.toml"
+    pyproject_file.write_text(
+        data=f"""
+[project]
+requires-python = "~=3.7"
+
+dependencies = [
+    "invoke ~={original_dependencies['invoke']}",
+    "tomlkit[test,docs] ~={original_dependencies['tomlkit']}",
+]
+
+[project.optional-dependencies]
+docs = [
+    "mike >={original_dependencies['mike']},<3",
+]
+testing = [
+    "pytest ~={original_dependencies['pytest']}",
+    "pytest-cov ~={original_dependencies['pytest-cov']}",
+]
+dev = [
+    "mike >={original_dependencies['mike']},<3",
+    "pytest ~={original_dependencies['pytest']}",
+    "pytest-cov ~={original_dependencies['pytest-cov']}",
+    "pre-commit ~={original_dependencies['pre-commit']}",
+    "pylint ~={original_dependencies['pylint']}",
+]
+""",
+        encoding="utf8",
+    )
+
+    context = MockContext(
+        run={
+            re.compile(r".*invoke$"): "invoke (1.7.1)",
+            re.compile(r".*tomlkit$"): "tomlkit (1.0.0)",
+            re.compile(r".*mike$"): "mike (1.0.1)",
+            re.compile(r".*pytest$"): "pytest (7.2.0)",
+            re.compile(r".*pytest-cov$"): "pytest-cov (3.1.0)",
+            re.compile(r".*pre-commit$"): "pre-commit (2.20.0)",
+            re.compile(r".*pylint$"): "pylint (2.14.0)",
+        },
+    )
+
+    update_deps(
+        context,
+        root_repo_path=str(tmp_path),
+        ignore=[
+            "dependency-name=*...update-types=version-update:semver-major",
+            "dependency-name=invoke...versions=>=2",
+            "dependency-name=mike...versions=<1",
+            "dependency-name=mike...versions=<=1.0.0",
+            "dependency-name=pylint...versions=~=2.14",
+            "dependency-name=pytest-cov...update-types=version-update:semver-minor",
+            "dependency-name=pytest",
+        ],
+        ignore_separator="...",
+    )
+
+    pyproject = tomlkit.loads(pyproject_file.read_bytes())
+
+    dependencies: list[str] = pyproject.get("project", {}).get("dependencies", [])
+    for optional_deps in (
+        pyproject.get("project", {}).get("optional-dependencies", {}).values()
+    ):
+        dependencies.extend(optional_deps)
+
+    for line in dependencies:
+        if "invoke" in line:
+            # Not affected by package-specific rule
+            assert line == "invoke ~=1.7"
+        elif "tomlkit" in line:
+            # Affected by "*" rule
+            assert line == "tomlkit[test,docs] ~=0.11.4"
+        elif "mike" in line:
+            # Not affected by any of its package-specific rules
+            assert line == "mike >=1.0,<3"
+        elif "pytest-cov" in line:
+            # Affected by its package-specific update-types rule
+            assert line == "pytest-cov ~=3.0"
+        elif "pytest" in line:
+            # Affected by package-specific rule (ignore all updates)
+            assert line == "pytest ~=7.1"
+        elif "pre-commit" in line:
+            # Not affected by "*" rule - no updates
+            assert line == "pre-commit ~=2.20"
+        elif "pylint" in line:
+            # Affected by its package-specific version rule
+            assert line == "pylint ~=2.13"
         else:
             pytest.fail(f"Unknown package in line: {line}")


### PR DESCRIPTION
Part 3 of closing #95.

To do:
- [x] Rebase on `main` after #109 and #110 have been merged.

Add and implement the `ignore` option for the `update-deps` invoke task.
This is a multi-input option, based on [version ignore rules from dependabot](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#ignore).

Essentially, it allows users to set a version range to ignore when trying to determine what should be included in a PR for updating dependencies in `pyproject.toml`. I.e., when used together with the [_CI - Check pyproject.toml dependencies_](https://sintef.github.io/ci-cd/latest/workflows/ci_check_pyproject_dependencies/) callable workflow.

Note, this is part 3 of 3 of a new set of PRs that replace #99.

Closes #95 