### PR TITLE
Activate auto-merge for pyproject.toml update PRs

### DIFF
--- a/.github/workflows/_local_ci_automerge_dependency_prs.yml
+++ b/.github/workflows/_local_ci_automerge_dependency_prs.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   update-dependencies-branch:
     name: Call reusable workflow
-    if: github.repository_owner == 'SINTEF' && startsWith(github.event.pull_request.head.ref, 'dependabot/') && github.actor == 'dependabot[bot]'
+    if: github.repository_owner == 'SINTEF' && ( ( startsWith(github.event.pull_request.head.ref, 'dependabot/') && github.actor == 'dependabot[bot]' ) || ( github.event.pull_request.head.ref == 'ci/update-pyproject' && github.actor == 'TEAM4-0' ) )
     uses: ./.github/workflows/ci_automerge_prs.yml
     secrets:
       PAT: ${{ secrets.RELEASE_PAT }}

--- a/docs/workflows/ci_automerge_prs.md
+++ b/docs/workflows/ci_automerge_prs.md
@@ -15,6 +15,9 @@ The motivation for being able to run changes prior to auto-merging, is to update
 Usually auto-merging is activated for [dependabot](https://docs.github.com/en/code-security/dependabot) branches, i.e., when a dependency/requirement is updated.
 Hence, the changes could include updating this dependency in documentation files or similar, where it will not be updated otherwise.
 
+!!! note "PR branch name"
+    The generated branch for the PR will be named `ci/update-pyproject`.
+
 ## Expectations
 
 The `PAT` secret must represent a user with the rights to activate auto-merging.

--- a/docs/workflows/ci_update_dependencies.md
+++ b/docs/workflows/ci_update_dependencies.md
@@ -12,6 +12,9 @@ The main point of having this workflow is to have a single PR, which can be squa
 
 As a "bonus" this workflow supports updating [pre-commit](https://pre-commit.com) hooks.
 
+!!! note "PR branch name"
+    The generated branch for the PR will be named `ci/update-dependencies`.
+
 !!! warning
     If a PAT is not passed through for the `PAT` secret and `GITHUB_TOKEN` is used, beware that any other CI/CD jobs that run for, e.g., pull request events, may not run since `GITHUB_TOKEN`-generated PRs are designed to not start more workflows to avoid escalation.
     Hence, if it is important to run CI/CD workflows for pull requests, consider passing a PAT as a secret to this workflow represented by the `PAT` secret.


### PR DESCRIPTION
Closes #101 

Extends activating auto-merge if a PR is generated by @TEAM4-0 and the PR branch is named `ci/update-pyproject`, which the branch is named when generated from the [_CI - Check pyproject.toml dependencies_](https://sintef.github.io/ci-cd/latest/workflows/ci_check_pyproject_dependencies/).

~Will add~ Added a bit of documentation to the _CI - Check pyproject.toml dependencies_ about the branch naming as well.

The branch names for generated branches used to open PRs was not mentioned anywhere in the documentation. This rectifies that by adding notes to the two relevant callable workflow documentation pages.