### PR TITLE
Use GitHub usernames in changelogs for releases

### DIFF
--- a/.github/workflows/_local_cd_release.yml
+++ b/.github/workflows/_local_cd_release.yml
@@ -1,14 +1,15 @@
 name: CD - Release
 
 on:
-  release:
-   types:
-     - "published"
+  # release:
+  #  types:
+  #    - "published"
+  push:
 
 jobs:
   publish:
     name: Call reusable workflow
-    if: github.repository == 'SINTEF/ci-cd' && startsWith(github.ref, 'refs/tags/v')
+    # if: github.repository == 'SINTEF/ci-cd' && startsWith(github.ref, 'refs/tags/v')
     uses: ./.github/workflows/cd_release.yml
     with:
       git_username: "TEAM 4.0[bot]"
@@ -17,10 +18,11 @@ jobs:
       publish_on_pypi: false
       package_dirs: ci_cd
       release_branch: main
-      update_docs: true
+      update_docs: false
       doc_extras: "[docs]"
       changelog_exclude_tags_regex: "^v[0-9]+$"  # Exclude 'v1' tag
-      test: false
+      changelog_exclude_labels: "CI/CD"
+      test: true
       version_update_changes_separator: ","
       version_update_changes: |
         {package_dir}/__init__.py,__version__ *= *(?:'|\").*(?:'|\"),__version__ = \"{version}\"

--- a/.github/workflows/_local_cd_release.yml
+++ b/.github/workflows/_local_cd_release.yml
@@ -1,15 +1,14 @@
 name: CD - Release
 
 on:
-  # release:
-  #  types:
-  #    - "published"
-  push:
+  release:
+   types:
+     - "published"
 
 jobs:
   publish:
     name: Call reusable workflow
-    # if: github.repository == 'SINTEF/ci-cd' && startsWith(github.ref, 'refs/tags/v')
+    if: github.repository == 'SINTEF/ci-cd' && startsWith(github.ref, 'refs/tags/v')
     uses: ./.github/workflows/cd_release.yml
     with:
       git_username: "TEAM 4.0[bot]"
@@ -18,11 +17,10 @@ jobs:
       publish_on_pypi: false
       package_dirs: ci_cd
       release_branch: main
-      update_docs: false
+      update_docs: true
       doc_extras: "[docs]"
       changelog_exclude_tags_regex: "^v[0-9]+$"  # Exclude 'v1' tag
-      changelog_exclude_labels: "CI/CD"
-      test: true
+      test: false
       version_update_changes_separator: ","
       version_update_changes: |
         {package_dir}/__init__.py,__version__ *= *(?:'|\").*(?:'|\"),__version__ = \"{version}\"

--- a/.github/workflows/cd_release.yml
+++ b/.github/workflows/cd_release.yml
@@ -145,7 +145,8 @@ jobs:
         else
           echo 'CHANGELOG_EXCLUDE_LABELS=' >> $GITHUB_ENV
         fi
-        echo 'CHANGELOG_PROJECT=--project "$(echo $GITHUB_REPOSITORY | cut -d/ -f2- )"' >> $GITHUB_ENV
+        PROJECT=$(echo $GITHUB_REPOSITORY | cut -d/ -f2- )
+        echo "CHANGELOG_PROJECT=--project ${PROJECT}" >> $GITHUB_ENV
 
     - name: Update changelog
       uses: docker://githubchangeloggenerator/github-changelog-generator:1.16.2

--- a/.github/workflows/cd_release.yml
+++ b/.github/workflows/cd_release.yml
@@ -145,11 +145,12 @@ jobs:
         else
           echo 'CHANGELOG_EXCLUDE_LABELS=' >> $GITHUB_ENV
         fi
+        echo 'CHANGELOG_PROJECT=--project "$(echo $GITHUB_REPOSITORY | cut -d/ -f2- )"' >> $GITHUB_ENV
 
     - name: Update changelog
       uses: docker://githubchangeloggenerator/github-changelog-generator:1.16.2
       with:
-        args: --user "${{ github.repository_owner }}" --project "$(echo $GITHUB_REPOSITORY | cut -d/ -f2- )" --token "${{ secrets.PAT || secrets.GITHUB_TOKEN }}" --release-branch "${{ inputs.release_branch }}" ${{ env.CHANGELOG_EXCLUDE_TAGS_REGEX }} ${{ env.CHANGELOG_EXCLUDE_LABELS }}
+        args: --user "${{ github.repository_owner }}" ${{ env.CHANGELOG_PROJECT }} --token "${{ secrets.PAT || secrets.GITHUB_TOKEN }}" --release-branch "${{ inputs.release_branch }}" ${{ env.CHANGELOG_EXCLUDE_TAGS_REGEX }} ${{ env.CHANGELOG_EXCLUDE_LABELS }}
 
     # - name: Update changelog
     #   uses: CharMixer/auto-changelog-action@v1
@@ -247,7 +248,7 @@ jobs:
     - name: Create release-specific changelog
       uses: docker://githubchangeloggenerator/github-changelog-generator:1.16.2
       with:
-        args: --user "${{ github.repository_owner }}" --project "$(echo $GITHUB_REPOSITORY | cut -d/ -f2- )" --token "${{ secrets.PAT || secrets.GITHUB_TOKEN }}" --release-branch "${{ inputs.release_branch }}" --since-tag "${{ env.PREVIOUS_VERSION }}" --output release_changelog.md ${{ env.CHANGELOG_EXCLUDE_TAGS_REGEX }} ${{ env.CHANGELOG_EXCLUDE_LABELS }}
+        args: --user "${{ github.repository_owner }}" ${{ env.CHANGELOG_PROJECT }} --token "${{ secrets.PAT || secrets.GITHUB_TOKEN }}" --release-branch "${{ inputs.release_branch }}" --since-tag "${{ env.PREVIOUS_VERSION }}" --output release_changelog.md ${{ env.CHANGELOG_EXCLUDE_TAGS_REGEX }} ${{ env.CHANGELOG_EXCLUDE_LABELS }}
 
     # - name: Create release-specific changelog
     #   uses: CharMixer/auto-changelog-action@v1

--- a/.github/workflows/cd_release.yml
+++ b/.github/workflows/cd_release.yml
@@ -249,7 +249,7 @@ jobs:
     - name: Create release-specific changelog
       uses: docker://githubchangeloggenerator/github-changelog-generator:1.16.2
       with:
-        args: --user "${{ github.repository_owner }}" ${{ env.CHANGELOG_PROJECT }} --token "${{ secrets.PAT || secrets.GITHUB_TOKEN }}" --release-branch "${{ inputs.release_branch }}" --since-tag "${{ env.PREVIOUS_VERSION }}" --output release_changelog.md ${{ env.CHANGELOG_EXCLUDE_TAGS_REGEX }} ${{ env.CHANGELOG_EXCLUDE_LABELS }}
+        args: --user "${{ github.repository_owner }}" ${{ env.CHANGELOG_PROJECT }} --token "${{ secrets.PAT || secrets.GITHUB_TOKEN }}" --release-branch "${{ inputs.release_branch }}" --since-tag "${{ env.PREVIOUS_VERSION }}" --output release_changelog.md --usernames-as-github-logins ${{ env.CHANGELOG_EXCLUDE_TAGS_REGEX }} ${{ env.CHANGELOG_EXCLUDE_LABELS }}
 
     # - name: Create release-specific changelog
     #   uses: CharMixer/auto-changelog-action@v1

--- a/.github/workflows/cd_release.yml
+++ b/.github/workflows/cd_release.yml
@@ -12,6 +12,11 @@ on:
         description: "A git user's email address (used to set the 'user.email' config option)."
         required: true
         type: string
+      release_branch:
+        description: "The branch name to release/publish from."
+        required: true
+        type: string
+        default: main
       # OPTIONAL
       python_package:
         description: "Whether or not this is a Python package, where the version should be updated in the 'package_dir'/__init__.py for the possibly several 'package_dir' lines given in the 'package_dirs' input and a build and release to PyPI should be performed."
@@ -23,11 +28,6 @@ on:
         required: false
         type: string
         default: ""
-      release_branch:
-        description: "The branch name to release/publish from."
-        required: false
-        type: string
-        default: main
       install_extras:
         description: "Any extras to install from the local repository through 'pip'. Must be encapsulated in square parentheses (`[]`) and be separated by commas (`,`) without any spaces. Example: `'[dev,release]'`."
         required: false
@@ -133,13 +133,31 @@ jobs:
         pip install ${EDITABLE}.${{ inputs.install_extras }}
         pip install git+https://github.com/SINTEF/ci-cd.git@v2.1.0
 
+    - name: Parse changelog configuration
+      run: |
+        if [ -n "${{ inputs.changelog_exclude_tags_regex }}" ]; then
+          echo 'CHANGELOG_EXCLUDE_TAGS_REGEX=--exclude-tags-regex "${{ inputs.changelog_exclude_tags_regex }}"' >> $GITHUB_ENV
+        else
+          echo 'CHANGELOG_EXCLUDE_TAGS_REGEX=' >> $GITHUB_ENV
+        fi
+        if [ -n "${{ inputs.changelog_exclude_labels}}" ]; then
+          echo 'CHANGELOG_EXCLUDE_LABELS=--exclude-labels "${{ inputs.changelog_exclude_labels }}"' >> $GITHUB_ENV
+        else
+          echo 'CHANGELOG_EXCLUDE_LABELS=' >> $GITHUB_ENV
+        fi
+
     - name: Update changelog
-      uses: CharMixer/auto-changelog-action@v1
+      uses: docker://githubchangeloggenerator/github-changelog-generator:1.16.2
       with:
-        token: ${{ secrets.PAT || secrets.GITHUB_TOKEN }}
-        release_branch: ${{ inputs.release_branch }}
-        exclude_tags_regex: "${{ inputs.changelog_exclude_tags_regex }}"
-        exclude_labels: "${{ inputs.changelog_exclude_labels }}"
+        args: --user "${{ github.repository_owner }}" --project "$(echo $GITHUB_REPOSITORY | cut -d/ -f2- )" --token "${{ secrets.PAT || secrets.GITHUB_TOKEN }}" --release-branch "${{ inputs.release_branch }}" ${{ env.CHANGELOG_EXCLUDE_TAGS_REGEX }} ${{ env.CHANGELOG_EXCLUDE_LABELS }}
+
+    # - name: Update changelog
+    #   uses: CharMixer/auto-changelog-action@v1
+    #   with:
+    #     token: ${{ secrets.PAT || secrets.GITHUB_TOKEN }}
+    #     release_branch: ${{ inputs.release_branch }}
+    #     exclude_tags_regex: "${{ inputs.changelog_exclude_tags_regex }}"
+    #     exclude_labels: "${{ inputs.changelog_exclude_labels }}"
 
     - name: Set up git user
       run: |
@@ -226,14 +244,19 @@ jobs:
         fi
 
     - name: Create release-specific changelog
-      uses: CharMixer/auto-changelog-action@v1
+      uses: docker://githubchangeloggenerator/github-changelog-generator:1.16.2
       with:
-        token: ${{ secrets.PAT || secrets.GITHUB_TOKEN }}
-        release_branch: ${{ inputs.release_branch }}
-        since_tag: "${{ env.PREVIOUS_VERSION }}"
-        output: "release_changelog.md"
-        exclude_tags_regex: "${{ inputs.changelog_exclude_tags_regex }}"
-        exclude_labels: "${{ inputs.changelog_exclude_labels }}"
+        args: --user "${{ github.repository_owner }}" --project "$(echo $GITHUB_REPOSITORY | cut -d/ -f2- )" --token "${{ secrets.PAT || secrets.GITHUB_TOKEN }}" --release-branch "${{ inputs.release_branch }}" --since-tag "${{ env.PREVIOUS_VERSION }}" --output release_changelog.md ${{ env.CHANGELOG_EXCLUDE_TAGS_REGEX }} ${{ env.CHANGELOG_EXCLUDE_LABELS }}
+
+    # - name: Create release-specific changelog
+    #   uses: CharMixer/auto-changelog-action@v1
+    #   with:
+    #     token: ${{ secrets.PAT || secrets.GITHUB_TOKEN }}
+    #     release_branch: ${{ inputs.release_branch }}
+    #     since_tag: "${{ env.PREVIOUS_VERSION }}"
+    #     output: "release_changelog.md"
+    #     exclude_tags_regex: "${{ inputs.changelog_exclude_tags_regex }}"
+    #     exclude_labels: "${{ inputs.changelog_exclude_labels }}"
 
     - name: Append changelog to release body
       run: |

--- a/.github/workflows/cd_release.yml
+++ b/.github/workflows/cd_release.yml
@@ -284,6 +284,15 @@ jobs:
     #     user: __token__
     #     password: ${{ secrets.PyPI_token }}
 
+    - name: TEMP - Upload changelogs as artifacts
+      uses: actions/upload-artifact@v3
+      with:
+        name: changelogs
+        path: |
+          ./CHANGELOG.md
+          ./release_changelog.md
+        retention-days: 1
+
   docs:
     name: Deploy release documentation
     needs: update-and-publish

--- a/.github/workflows/cd_release.yml
+++ b/.github/workflows/cd_release.yml
@@ -109,7 +109,7 @@ on:
 jobs:
   update-and-publish:
     name: Update CHANGELOG and version and publish to PyPI
-    if: startsWith(github.ref, 'refs/tags/v')
+    # if: startsWith(github.ref, 'refs/tags/v')
     runs-on: ubuntu-latest
 
     steps:
@@ -166,8 +166,9 @@ jobs:
 
     - name: Update version and tag
       run: |
-        REF=${{ github.ref }}
-        REF=${REF#refs/tags/}
+        # REF=${{ github.ref }}
+        # REF=${REF#refs/tags/}
+        REF=v10.0.0
 
         if [ "${{ inputs.python_package }}" == "true" ]; then
           if [ -z "${{ inputs.package_dirs }}" ]; then
@@ -224,16 +225,16 @@ jobs:
         git checkout -- .
         ${{ inputs.build_cmd }}
 
-    - name: Update '${{ inputs.release_branch }}'
-      uses: CasperWA/push-protected@v2
-      with:
-        token: ${{ secrets.PAT || secrets.GITHUB_TOKEN }}
-        branch: ${{ inputs.release_branch }}
-        sleep: 15
-        force: true
-        tags: true
-        unprotect_reviews: true
-        debug: ${{ inputs.test }}
+    # - name: Update '${{ inputs.release_branch }}'
+    #   uses: CasperWA/push-protected@v2
+    #   with:
+    #     token: ${{ secrets.PAT || secrets.GITHUB_TOKEN }}
+    #     branch: ${{ inputs.release_branch }}
+    #     sleep: 15
+    #     force: true
+    #     tags: true
+    #     unprotect_reviews: true
+    #     debug: ${{ inputs.test }}
 
     - name: Get tagged versions
       run: |
@@ -258,28 +259,28 @@ jobs:
     #     exclude_tags_regex: "${{ inputs.changelog_exclude_tags_regex }}"
     #     exclude_labels: "${{ inputs.changelog_exclude_labels }}"
 
-    - name: Append changelog to release body
-      run: |
-        gh api /repos/${{ github.repository }}/releases/${{ github.event.release.id }} --jq '.body' > release_body.md
-        cat release_changelog.md >> release_body.md
-        gh api /repos/${{ github.repository }}/releases/${{ github.event.release.id }} -X PATCH -F body='@release_body.md'
-      env:
-        GITHUB_TOKEN: ${{ secrets.PAT || secrets.GITHUB_TOKEN }}
+    # - name: Append changelog to release body
+    #   run: |
+    #     gh api /repos/${{ github.repository }}/releases/${{ github.event.release.id }} --jq '.body' > release_body.md
+    #     cat release_changelog.md >> release_body.md
+    #     gh api /repos/${{ github.repository }}/releases/${{ github.event.release.id }} -X PATCH -F body='@release_body.md'
+    #   env:
+    #     GITHUB_TOKEN: ${{ secrets.PAT || secrets.GITHUB_TOKEN }}
 
-    - name: Publish package to TestPyPI
-      if: inputs.test && inputs.publish_on_pypi && inputs.python_package
-      uses: pypa/gh-action-pypi-publish@v1.6.4
-      with:
-        user: __token__
-        password: ${{ secrets.PyPI_token }}
-        repository_url: https://test.pypi.org/legacy/
+    # - name: Publish package to TestPyPI
+    #   if: inputs.test && inputs.publish_on_pypi && inputs.python_package
+    #   uses: pypa/gh-action-pypi-publish@v1.6.4
+    #   with:
+    #     user: __token__
+    #     password: ${{ secrets.PyPI_token }}
+    #     repository_url: https://test.pypi.org/legacy/
 
-    - name: Publish package to PyPI
-      if: ( ! inputs.test ) && inputs.publish_on_pypi && inputs.python_package
-      uses: pypa/gh-action-pypi-publish@v1.6.4
-      with:
-        user: __token__
-        password: ${{ secrets.PyPI_token }}
+    # - name: Publish package to PyPI
+    #   if: ( ! inputs.test ) && inputs.publish_on_pypi && inputs.python_package
+    #   uses: pypa/gh-action-pypi-publish@v1.6.4
+    #   with:
+    #     user: __token__
+    #     password: ${{ secrets.PyPI_token }}
 
   docs:
     name: Deploy release documentation

--- a/.github/workflows/cd_release.yml
+++ b/.github/workflows/cd_release.yml
@@ -284,15 +284,6 @@ jobs:
     #     user: __token__
     #     password: ${{ secrets.PyPI_token }}
 
-    - name: TEMP - Upload changelogs as artifacts
-      uses: actions/upload-artifact@v3
-      with:
-        name: changelogs
-        path: |
-          ./CHANGELOG.md
-          ./release_changelog.md
-        retention-days: 1
-
   docs:
     name: Deploy release documentation
     needs: update-and-publish

--- a/.github/workflows/cd_release.yml
+++ b/.github/workflows/cd_release.yml
@@ -153,14 +153,6 @@ jobs:
       with:
         args: --user "${{ github.repository_owner }}" ${{ env.CHANGELOG_PROJECT }} --token "${{ secrets.PAT || secrets.GITHUB_TOKEN }}" --release-branch "${{ inputs.release_branch }}" ${{ env.CHANGELOG_EXCLUDE_TAGS_REGEX }} ${{ env.CHANGELOG_EXCLUDE_LABELS }}
 
-    # - name: Update changelog
-    #   uses: CharMixer/auto-changelog-action@v1
-    #   with:
-    #     token: ${{ secrets.PAT || secrets.GITHUB_TOKEN }}
-    #     release_branch: ${{ inputs.release_branch }}
-    #     exclude_tags_regex: "${{ inputs.changelog_exclude_tags_regex }}"
-    #     exclude_labels: "${{ inputs.changelog_exclude_labels }}"
-
     - name: Set up git user
       run: |
         git config --global user.name "${{ inputs.git_username }}"
@@ -249,16 +241,6 @@ jobs:
       uses: docker://githubchangeloggenerator/github-changelog-generator:1.16.2
       with:
         args: --user "${{ github.repository_owner }}" ${{ env.CHANGELOG_PROJECT }} --token "${{ secrets.PAT || secrets.GITHUB_TOKEN }}" --release-branch "${{ inputs.release_branch }}" --since-tag "${{ env.PREVIOUS_VERSION }}" --output release_changelog.md --usernames-as-github-logins ${{ env.CHANGELOG_EXCLUDE_TAGS_REGEX }} ${{ env.CHANGELOG_EXCLUDE_LABELS }}
-
-    # - name: Create release-specific changelog
-    #   uses: CharMixer/auto-changelog-action@v1
-    #   with:
-    #     token: ${{ secrets.PAT || secrets.GITHUB_TOKEN }}
-    #     release_branch: ${{ inputs.release_branch }}
-    #     since_tag: "${{ env.PREVIOUS_VERSION }}"
-    #     output: "release_changelog.md"
-    #     exclude_tags_regex: "${{ inputs.changelog_exclude_tags_regex }}"
-    #     exclude_labels: "${{ inputs.changelog_exclude_labels }}"
 
     - name: Append changelog to release body
       run: |

--- a/.github/workflows/cd_release.yml
+++ b/.github/workflows/cd_release.yml
@@ -109,7 +109,7 @@ on:
 jobs:
   update-and-publish:
     name: Update CHANGELOG and version and publish to PyPI
-    # if: startsWith(github.ref, 'refs/tags/v')
+    if: startsWith(github.ref, 'refs/tags/v')
     runs-on: ubuntu-latest
 
     steps:
@@ -168,9 +168,8 @@ jobs:
 
     - name: Update version and tag
       run: |
-        # REF=${{ github.ref }}
-        # REF=${REF#refs/tags/}
-        REF=v10.0.0
+        REF=${{ github.ref }}
+        REF=${REF#refs/tags/}
 
         if [ "${{ inputs.python_package }}" == "true" ]; then
           if [ -z "${{ inputs.package_dirs }}" ]; then
@@ -227,16 +226,16 @@ jobs:
         git checkout -- .
         ${{ inputs.build_cmd }}
 
-    # - name: Update '${{ inputs.release_branch }}'
-    #   uses: CasperWA/push-protected@v2
-    #   with:
-    #     token: ${{ secrets.PAT || secrets.GITHUB_TOKEN }}
-    #     branch: ${{ inputs.release_branch }}
-    #     sleep: 15
-    #     force: true
-    #     tags: true
-    #     unprotect_reviews: true
-    #     debug: ${{ inputs.test }}
+    - name: Update '${{ inputs.release_branch }}'
+      uses: CasperWA/push-protected@v2
+      with:
+        token: ${{ secrets.PAT || secrets.GITHUB_TOKEN }}
+        branch: ${{ inputs.release_branch }}
+        sleep: 15
+        force: true
+        tags: true
+        unprotect_reviews: true
+        debug: ${{ inputs.test }}
 
     - name: Get tagged versions
       run: |
@@ -261,28 +260,28 @@ jobs:
     #     exclude_tags_regex: "${{ inputs.changelog_exclude_tags_regex }}"
     #     exclude_labels: "${{ inputs.changelog_exclude_labels }}"
 
-    # - name: Append changelog to release body
-    #   run: |
-    #     gh api /repos/${{ github.repository }}/releases/${{ github.event.release.id }} --jq '.body' > release_body.md
-    #     cat release_changelog.md >> release_body.md
-    #     gh api /repos/${{ github.repository }}/releases/${{ github.event.release.id }} -X PATCH -F body='@release_body.md'
-    #   env:
-    #     GITHUB_TOKEN: ${{ secrets.PAT || secrets.GITHUB_TOKEN }}
+    - name: Append changelog to release body
+      run: |
+        gh api /repos/${{ github.repository }}/releases/${{ github.event.release.id }} --jq '.body' > release_body.md
+        cat release_changelog.md >> release_body.md
+        gh api /repos/${{ github.repository }}/releases/${{ github.event.release.id }} -X PATCH -F body='@release_body.md'
+      env:
+        GITHUB_TOKEN: ${{ secrets.PAT || secrets.GITHUB_TOKEN }}
 
-    # - name: Publish package to TestPyPI
-    #   if: inputs.test && inputs.publish_on_pypi && inputs.python_package
-    #   uses: pypa/gh-action-pypi-publish@v1.6.4
-    #   with:
-    #     user: __token__
-    #     password: ${{ secrets.PyPI_token }}
-    #     repository_url: https://test.pypi.org/legacy/
+    - name: Publish package to TestPyPI
+      if: inputs.test && inputs.publish_on_pypi && inputs.python_package
+      uses: pypa/gh-action-pypi-publish@v1.6.4
+      with:
+        user: __token__
+        password: ${{ secrets.PyPI_token }}
+        repository_url: https://test.pypi.org/legacy/
 
-    # - name: Publish package to PyPI
-    #   if: ( ! inputs.test ) && inputs.publish_on_pypi && inputs.python_package
-    #   uses: pypa/gh-action-pypi-publish@v1.6.4
-    #   with:
-    #     user: __token__
-    #     password: ${{ secrets.PyPI_token }}
+    - name: Publish package to PyPI
+      if: ( ! inputs.test ) && inputs.publish_on_pypi && inputs.python_package
+      uses: pypa/gh-action-pypi-publish@v1.6.4
+      with:
+        user: __token__
+        password: ${{ secrets.PyPI_token }}
 
   docs:
     name: Deploy release documentation

--- a/.github/workflows/ci_cd_updated_default_branch.yml
+++ b/.github/workflows/ci_cd_updated_default_branch.yml
@@ -272,17 +272,29 @@ jobs:
         tags: true
         unprotect_reviews: true
 
+    - name: Parse changelog configuration
+      if: env.RELEASE_RUN == 'false'
+      run: |
+        if [ -n "${{ inputs.changelog_exclude_tags_regex }}" ]; then
+          echo 'CHANGELOG_EXCLUDE_TAGS_REGEX=--exclude-tags-regex "${{ inputs.changelog_exclude_tags_regex }}"' >> $GITHUB_ENV
+        else
+          echo 'CHANGELOG_EXCLUDE_TAGS_REGEX=' >> $GITHUB_ENV
+        fi
+        if [ -n "${{ inputs.changelog_exclude_labels}}" ]; then
+          echo 'CHANGELOG_EXCLUDE_LABELS=--exclude-labels "${{ inputs.changelog_exclude_labels }}"' >> $GITHUB_ENV
+        else
+          echo 'CHANGELOG_EXCLUDE_LABELS=' >> $GITHUB_ENV
+        fi
+        PROJECT=$(echo $GITHUB_REPOSITORY | cut -d/ -f2- )
+        echo "CHANGELOG_PROJECT=--project ${PROJECT}" >> $GITHUB_ENV
+
     # Note: This updated changelog will only exist for the `latest` documentation
     # release.
     - name: Update changelog with unreleased changes
       if: env.RELEASE_RUN == 'false'
-      uses: CharMixer/auto-changelog-action@v1
+      uses: docker://githubchangeloggenerator/github-changelog-generator:1.16.2
       with:
-        token: ${{ secrets.PAT || secrets.GITHUB_TOKEN }}
-        release_branch: ${{ inputs.default_repo_branch }}
-        exclude_tags_regex: "${{ inputs.changelog_exclude_tags_regex }}"
-        exclude_labels: "${{ inputs.changelog_exclude_labels }}"
-        future_release: "Unreleased changes"
+        args: --user "${{ github.repository_owner }}" ${{ env.CHANGELOG_PROJECT }} --token "${{ secrets.PAT || secrets.GITHUB_TOKEN }}" --release-branch "${{ inputs.default_repo_branch }}" --future-release "Unreleased changes" ${{ env.CHANGELOG_EXCLUDE_TAGS_REGEX }} ${{ env.CHANGELOG_EXCLUDE_LABELS }}
 
     - name: Deploy documentation
       if: env.RELEASE_RUN == 'false' && ( ! inputs.test )

--- a/docs/workflows/cd_release.md
+++ b/docs/workflows/cd_release.md
@@ -67,9 +67,9 @@ The repository contains the following:
 |:--- |:--- |:---:|:---:|:---:|
 | `git_username` | A git username (used to set the 'user.name' config option). | **_Yes_** | | _string_ |
 | `git_email` | A git user's email address (used to set the 'user.email' config option). | **_Yes_** | | _string_ |
+| `release_branch` | The branch name to release/publish from. | **_Yes_** | main | _string_ |
 | `python_package` | Whether or not this is a Python package, where the version should be updated in the `'package_dir'/__init__.py` for the possibly several 'package_dir' lines given in the `package_dirs` input and a build and release to PyPI should be performed. | No | `true` | _boolean_ |
 | `package_dirs` |  single or multi-line string of paths to Python package directories relative to the repository directory to have its `__version__` value updated.</br></br>Example: `'src/my_package'`.</br></br>**Important**: This is _required_ if 'python_package' is 'true', which is the default. | **_Yes_ (if 'python_package' is 'true'** | | _string_ |
-| `release_branch` | The branch name to release/publish from. | No | main | _string_ |
 | `install_extras` | Any extras to install from the local repository through 'pip'. Must be encapsulated in square parentheses (`[]`) and be separated by commas (`,`) without any spaces.</br></br>Example: `'[dev,release]'`. | No | _Empty string_ | _string_ |
 | `relative` | Whether or not to use install the local Python package(s) as an editable. | No | `false` | _boolean_ |
 | `python_version_build` | The Python version to use for the workflow when building the package. | No | 3.9 | _string_ |


### PR DESCRIPTION
Closes #102 

Updates [_CD - Release_](https://sintef.github.io/ci-cd/latest/workflows/cd_release/) to use the [github-changelog-generator](https://github.com/github-changelog-generator/github-changelog-generator) directly from the public [Docker image](https://hub.docker.com/r/githubchangeloggenerator/github-changelog-generator), instead of the GitHub Actions [CharMixer/auto-changelog-action](https://github.com/charmixer/auto-changelog-action), which essentially proxies usage of that same Docker image.
The reason for this switch is the need to use the `--usernames-as-github-logins` option, which is not supported by the proxy action. The action is quite static in terms of the supported options and does not allow one to add miscellaneous options.
Instead, since GitHub Actions supports using public Docker images straight up as a step, this is done, passing in the options to the generator tool via the `args` input. It's a bit more opaque concerning the options passed to the generator tool now, however, the freedom to use whichever option we want is apparent.

In order to parse the options correctly, a pre-parsing step has been introduced to the workflow.

Indeed, to completely remove the Action from this repository seemed to be the most straight-forward thing to do, hence this switch has also been implemented for the [_CI/CD - New updates to default branch_](https://sintef.github.io/ci-cd/latest/workflows/ci_cd_updated_default_branch/) workflow, which creates a temporary changelog with unreleased changes for the `latest` "version" in the documentation.

Finally, the `--usernames-as-github-logins` option is added to the changelog generation, which is then appended to the release description, making all named contributions into GitHub handles (instead of markdown links). This will auto-add "contributors" on the GitHub page of the release.

Markdown links are kept for other generated changelogs, since these are mainly shown in the documentation, which needs these named references to be full links.