### PR TITLE
Use the proper "ignore" option name for update-deps

### DIFF
--- a/.github/workflows/ci_check_pyproject_dependencies.yml
+++ b/.github/workflows/ci_check_pyproject_dependencies.yml
@@ -90,7 +90,7 @@ jobs:
 
         IGNORE_OPTIONS=()
         while IFS= read -r line; do
-          if [ -n "${line}" ]; then IGNORE_OPTIONS+=(--ignore-options="${line}"); fi
+          if [ -n "${line}" ]; then IGNORE_OPTIONS+=(--ignore="${line}"); fi
         done <<< "${{ inputs.ignore }}"
 
         ci-cd update-deps ${FAIL_FAST} \


### PR DESCRIPTION
Fixes #125 

This updates the generated `--ignore` option argument input to `ci-cd update-deps` from the callable workflow.
A quick search through the repository revealed `ci-cd update-deps` is not called anywhere else. The error was also not relevant for the documentation about the callable workflow, as the input variable name for the callable workflow is unrelated to the option argument.