### PR TITLE
Use CODECOV_TOKEN secret in CI

### DIFF
--- a/.github/workflows/_local_ci_tests.yml
+++ b/.github/workflows/_local_ci_tests.yml
@@ -65,3 +65,4 @@ jobs:
       uses: codecov/codecov-action@v3
       with:
         fail_ci_if_error: true
+        token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
Fixes #119 

Use a secret token when uploading to Codecov.io. While this is not strictly necessary (public repository) it should help minimize the upload issues we are seeing a lot at the moment - and it doesn't hurt.