### PR TITLE
Fix logic for checking documentation framework

### DIFF
--- a/.github/workflows/cd_release.yml
+++ b/.github/workflows/cd_release.yml
@@ -318,10 +318,11 @@ jobs:
     steps:
     - name: Check input
       run: |
-        if [[ "${{ inputs.docs_framework }}" != "mkdocs" || "${{ inputs.docs_framework }}" != "sphinx" ]]; then
-          echo "The input 'docs_framework' must be either 'mkdocs' or 'sphinx' !"
-          echo "Found value: ${{ inputs.docs_framework }}"
-          exit 1
+        valid_frameworks=("mkdocs sphinx")
+        if [[ ! " ${valid_frameworks[*]} " =~ " ${{ inputs.docs_framework}} " ]]; then
+            echo "The input '${{ inputs.docs_framework}}' is not supported."
+            echo "Valid inputs are: ${valid_frameworks[*]}"
+            exit 1
         fi
 
     - name: Checkout ${{ github.repository }}

--- a/.github/workflows/ci_cd_updated_default_branch.yml
+++ b/.github/workflows/ci_cd_updated_default_branch.yml
@@ -166,10 +166,11 @@ jobs:
     steps:
     - name: Check input
       run: |
-        if [[ "${{ inputs.docs_framework }}" != "mkdocs" || "${{ inputs.docs_framework }}" != "sphinx" ]]; then
-          echo "The input 'docs_framework' must be either 'mkdocs' or 'sphinx' !"
-          echo "Found value: ${{ inputs.docs_framework }}"
-          exit 1
+        valid_frameworks=("mkdocs sphinx")
+        if [[ ! " ${valid_frameworks[*]} " =~ " ${{ inputs.docs_framework}} " ]]; then
+            echo "The input '${{ inputs.docs_framework}}' is not supported."
+            echo "Valid inputs are: ${valid_frameworks[*]}"
+            exit 1
         fi
 
     - name: Release check

--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -318,9 +318,11 @@ jobs:
           ("${{ inputs.use_mkdocs }}" == "false" && "${{ inputs.use_sphinx }}" == "false") || \
           ("${{ inputs.use_mkdocs }}" == "true" && "${{ inputs.use_sphinx }}" == "false") ]]; then
           # (Default to) using MkDocs
+          echo "Framework determined: MkDocs"
           echo "framework=mkdocs" >> $GITHUB_ENV
         elif [[ "${{ inputs.use_mkdocs }}" == "false" && "${{ inputs.use_sphinx }}" == "true" ]]; then
           # Use Sphinx
+          echo "Framework determined: Sphinx"
           echo "framework=sphinx" >> $GITHUB_ENV
         else
           echo "Could not determine what documentation framework to use."


### PR DESCRIPTION
Fixes #152 

I started out creating a separate bash script to call for these checks. In that way it was possible to unit test the bash parts run in the workflow.
However, it turned out to be quite overkill for what's needed, så instead I fixed the immediate issue and attempted to search for more.

In the end, it might still be nice to have a separate bash script - or even implement utility tools into the Python `ci-cd` package - to call and have separate unit tests for to ensure it all works as intended.