### PR TITLE
Support Windows for pre-commit hook usage

### DIFF
--- a/.github/utils/.pre-commit-config_testing.yaml
+++ b/.github/utils/.pre-commit-config_testing.yaml
@@ -30,5 +30,5 @@ repos:
       minimum_pre_commit_version: "2.16.0"
       args:
       - "--package-dir=ci_cd"
-      - "--version=9.8.7"
+      - "--version=0.0.0"
       - "--test"

--- a/.github/utils/.pre-commit-config_testing.yaml
+++ b/.github/utils/.pre-commit-config_testing.yaml
@@ -1,0 +1,34 @@
+repos:
+  - repo: .
+    rev: HEAD
+    hooks:
+    - id: docs-api-reference
+      args:
+      - "--package-dir=ci_cd"
+      - "--debug"
+    - id: docs-landing-page
+    - id: update-pyproject
+
+  - repo: local
+    hooks:
+    - id: set-version
+      name: Set package version
+      entry: "ci-cd setver"
+      language: python
+      files: ""
+      exclude: ^$
+      types: []
+      types_or: []
+      exclude_types: []
+      always_run: false
+      fail_fast: false
+      verbose: false
+      pass_filenames: false
+      require_serial: false
+      description: "Sets the specified version of specified Python package."
+      language_version: default
+      minimum_pre_commit_version: "2.16.0"
+      args:
+      - "--package-dir=ci_cd"
+      - "--version=9.8.7"
+      - "--test"

--- a/.github/utils/run_hooks.py
+++ b/.github/utils/run_hooks.py
@@ -5,7 +5,7 @@ File used to test running the hooks in the CI/CD pipeline independently of the s
 """
 from __future__ import annotations
 
-import platform
+# import platform
 import subprocess  # nosec
 import sys
 
@@ -24,22 +24,13 @@ def main(hook: str, options: list[str]) -> None:
         "--all-files --verbose"
     )
 
-    if platform.system() == "Windows":
-        result = subprocess.run(
-            f"py -m {run_pre_commit} {options} {hook}",
-            check=False,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.STDOUT,
-            shell=True,  # nosec
-        )
-    else:
-        result = subprocess.run(
-            f"{run_pre_commit} {options} {hook}",
-            check=False,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.STDOUT,
-            shell=True,  # nosec
-        )
+    result = subprocess.run(
+        f"{run_pre_commit} {options} {hook}",
+        check=False,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        shell=True,  # nosec
+    )
 
     if result.returncode != 0:
         if SUCCESSFUL_FAILURES_MAPPING[hook] in result.stdout.decode():

--- a/.github/utils/run_hooks.py
+++ b/.github/utils/run_hooks.py
@@ -3,6 +3,8 @@
 
 File used to test running the hooks in the CI/CD pipeline independently of the shell.
 """
+from __future__ import annotations
+
 import platform
 import subprocess  # nosec
 import sys

--- a/.github/utils/run_hooks.py
+++ b/.github/utils/run_hooks.py
@@ -17,18 +17,14 @@ SUCCESSFUL_FAILURES_MAPPING = {
 
 def main(hook: str, options: list[str]) -> None:
     """Run pre-commit hooks on all files in the repository."""
-    run_pre_commit = [
-        "pre-commit",
-        "run",
-        "-c",
-        ".github/utils/.pre-commit-config_testing.yaml",
-        "--all-files",
-        "--verbose",
-    ]
+    run_pre_commit = (
+        "pre-commit run -c .github/utils/.pre-commit-config_testing.yaml "
+        "--all-files --verbose"
+    )
 
     if platform.system() == "Windows":
         result = subprocess.run(
-            ["py", "-m"] + run_pre_commit + options + [hook],
+            f"py -m {run_pre_commit} {options} {hook}",
             check=False,
             stdout=subprocess.PIPE,
             stderr=subprocess.STDOUT,
@@ -36,7 +32,7 @@ def main(hook: str, options: list[str]) -> None:
         )
     else:
         result = subprocess.run(
-            run_pre_commit + options + [hook],
+            f"{run_pre_commit} {options} {hook}",
             check=False,
             stdout=subprocess.PIPE,
             stderr=subprocess.STDOUT,

--- a/.github/utils/run_hooks.py
+++ b/.github/utils/run_hooks.py
@@ -1,0 +1,75 @@
+#!/usr/bin/env python3
+"""Run pre-commit hooks on all files in the repository.
+
+File used to test running the hooks in the CI/CD pipeline independently of the shell.
+"""
+import platform
+import subprocess  # nosec
+import sys
+
+SUCCESSFUL_FAILURES_MAPPING = {
+    "docs-api-reference": "The following files have been changed/added/removed:",
+    "docs-landing-page": "The landing page has been updated.",
+    "update-pyproject": "Successfully updated the following dependencies:",
+    "set-version": "Bumped version for ci_cd to 0.0.0.",
+}
+
+
+def main(hook: str, options: list[str]) -> None:
+    """Run pre-commit hooks on all files in the repository."""
+    run_pre_commit = [
+        "pre-commit",
+        "run",
+        "-c",
+        ".github/utils/.pre-commit-config_testing.yaml",
+        "--all-files",
+        "--verbose",
+    ]
+
+    if platform.system() == "Windows":
+        result = subprocess.run(
+            ["py", "-m"] + run_pre_commit + options + [hook],
+            check=False,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            shell=True,  # nosec
+        )
+    else:
+        result = subprocess.run(
+            run_pre_commit + options + [hook],
+            check=False,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            shell=True,  # nosec
+        )
+
+    if result.returncode != 0:
+        if SUCCESSFUL_FAILURES_MAPPING[hook] in result.stdout.decode():
+            print(f"Successfully failed {hook} hook.\n\n", flush=True)
+            print(result.stdout.decode(), flush=True)
+        else:
+            sys.exit(result.stdout.decode())
+    print(f"Successfully ran {hook} hook.\n\n", flush=True)
+    print(result.stdout.decode(), flush=True)
+
+
+if __name__ == "__main__":
+    if len(sys.argv) < 2:
+        raise sys.exit("Missing arguments")
+
+    # "Parse" arguments
+    # The first argument should be the hook name
+    if sys.argv[1] not in SUCCESSFUL_FAILURES_MAPPING:
+        raise sys.exit(
+            f"Invalid hook name: {sys.argv[1]}\n"
+            "The hook name should be the first argument. Any number of hook options "
+            "can then follow."
+        )
+
+    try:
+        main(
+            hook=sys.argv[1],
+            options=sys.argv[2:] if len(sys.argv) > 2 else [],
+        )
+    except Exception as exc:  # pylint: disable=broad-except
+        sys.exit(str(exc))

--- a/.github/utils/run_hooks.py
+++ b/.github/utils/run_hooks.py
@@ -25,7 +25,7 @@ def main(hook: str, options: list[str]) -> None:
     )
 
     result = subprocess.run(
-        f"{run_pre_commit} {options} {hook}",
+        f"{run_pre_commit} {' '.join(_ for _ in options)} {hook}",
         check=False,
         stdout=subprocess.PIPE,
         stderr=subprocess.STDOUT,

--- a/.github/workflows/_local_ci_tests.yml
+++ b/.github/workflows/_local_ci_tests.yml
@@ -130,8 +130,3 @@ jobs:
       if: runner.os == 'Windows'
       run: python .github/utils/run_hooks.py set-version
       shell: cmd
-
-    - name: Bare run
-      if: runner.os == 'Windows'
-      run: pre-commit run -c .github/utils/.pre-commit-config_testing.yaml --all-files --verbose docs-api-reference
-      shell: cmd

--- a/.github/workflows/_local_ci_tests.yml
+++ b/.github/workflows/_local_ci_tests.yml
@@ -97,131 +97,36 @@ jobs:
 
     # docs-api-reference
     - name: Run docs-api-reference ('ci-cd create-api-reference-docs')
-      continue-on-error: true
-      id: docs_api_reference
-      run: |
-        {
-          echo 'docs_api_reference_output<<EOF'
-          pre-commit run -c .github/utils/.pre-commit-config_testing.yaml --all-files --verbose docs-api-reference
-          echo EOF
-        } >> "$GITHUB_ENV"
-
-    - name: Check if failure is expected/acceptible
-      if: steps.docs_api_reference.outcome == 'failure'
-      run: printf '%s\n' "$docs_api_reference_output" | grep "The following files have been changed/added/removed:" | exit 0 || exit 1
-      shell: bash
+      run: python .github/utils/run_hooks.py docs-api-reference
 
     - name: Run docs-api-reference ('ci-cd create-api-reference-docs') (cmd)
       if: runner.os == 'Windows'
-      continue-on-error: true
-      id: docs_api_reference_cmd
-      run: |
-        {
-          echo 'docs_api_reference_output<<EOF'
-          pre-commit run -c .github/utils/.pre-commit-config_testing.yaml --all-files --verbose docs-api-reference
-          echo EOF
-        } >> "$GITHUB_ENV"
+      run: python .github/utils/run_hooks.py docs-api-reference
       shell: cmd
-
-    - name: Check if failure is expected/acceptible
-      if: runner.os == 'Windows' && steps.docs_api_reference_cmd.outcome == 'failure'
-      run: printf '%s\n' "$docs_api_reference_output" | grep "The following files have been changed/added/removed:" | exit 0 || exit 1
-      shell: bash
 
     # docs-landing-page
     - name: Run docs-landing-page ('ci-cd create-docs-index')
-      continue-on-error: true
-      id: docs_landing_page
-      run: |
-        {
-          echo 'docs_landing_page_output<<EOF'
-          pre-commit run -c .github/utils/.pre-commit-config_testing.yaml --all-files --verbose docs-landing-page
-          echo EOF
-        } >> "$GITHUB_ENV"
-
-    - name: Check if failure is expected/acceptible
-      if: steps.docs_landing_page.outcome == 'failure'
-      run: printf '%s\n' "$docs_landing_page_output" | grep "The landing page has been updated." | exit 0 || exit 1
-      shell: bash
+      run: python .github/utils/run_hooks.py docs-landing-page
 
     - name: Run docs-landing-page ('ci-cd create-docs-index') (cmd)
       if: runner.os == 'Windows'
-      continue-on-error: true
-      id: docs_landing_page_cmd
-      run: |
-        {
-          echo 'docs_landing_page_output<<EOF'
-          pre-commit run -c .github/utils/.pre-commit-config_testing.yaml --all-files --verbose docs-landing-page
-          echo EOF
-        } >> "$GITHUB_ENV"
+      run: python .github/utils/run_hooks.py docs-landing-page
       shell: cmd
-
-    - name: Check if failure is expected/acceptible
-      if: runner.os == 'Windows' && steps.docs_landing_page_cmd.outcome == 'failure'
-      run: printf '%s\n' "$docs_landing_page_output" | grep "The landing page has been updated." | exit 0 || exit 1
-      shell: bash
 
     # update-pyproject
     - name: Run update-pyproject ('ci-cd update-deps')
-      continue-on-error: true
-      id: update_pyproject
-      run: |
-        {
-          echo 'update_pyproject_output<<EOF'
-          pre-commit run -c .github/utils/.pre-commit-config_testing.yaml --all-files --verbose update-pyproject
-          echo EOF
-        } >> "$GITHUB_ENV"
-
-    - name: Check if failure is expected/acceptible
-      if: steps.update_pyproject.outcome == 'failure'
-      run: printf '%s\n' "$update_pyproject_output" | grep "Successfully updated the following dependencies:" | exit 0 || exit 1
-      shell: bash
+      run: python .github/utils/run_hooks.py update-pyproject
 
     - name: Run update-pyproject ('ci-cd update-deps') (cmd)
       if: runner.os == 'Windows'
-      continue-on-error: true
-      id: update_pyproject_cmd
-      run: |
-        {
-          echo 'update_pyproject_output<<EOF'
-          pre-commit run -c .github/utils/.pre-commit-config_testing.yaml --all-files --verbose update-pyproject
-          echo EOF
-        } >> "$GITHUB_ENV"
+      run: python .github/utils/run_hooks.py update-pyproject
       shell: cmd
-
-    - name: Check if failure is expected/acceptible
-      if: runner.os == 'Windows' && steps.update_pyproject_cmd.outcome == 'failure'
-      run: printf '%s\n' "$update_pyproject_output" | grep "Successfully updated the following dependencies:" | exit 0 || exit 1
-      shell: bash
 
     # set-version
     - name: Run 'ci-cd setver'
-      continue-on-error: true
-      id: set_version
-      run: |
-        {
-          echo 'set_version_output<<EOF'
-          pre-commit run -c .github/utils/.pre-commit-config_testing.yaml --all-files --verbose set-version
-          echo EOF
-        } >> "$GITHUB_ENV"
-
-    - name: Check if failure is expected/acceptible
-      if: steps.set_version.outcome == 'failure'
-      run: printf '%s\n' "$set_version_output" | grep "Bumped version for ci_cd to 0.0.0." | exit 0 || exit 1
-      shell: bash
+      run: python .github/utils/run_hooks.py set-version
 
     - name: Run 'ci-cd setver' (cmd)
       if: runner.os == 'Windows'
-      continue-on-error: true
-      id: set_version_cmd
-      run: |
-        {
-          echo 'set_version_output<<EOF'
-          pre-commit run -c .github/utils/.pre-commit-config_testing.yaml --all-files --verbose set-version
-          echo EOF
-        } >> "$GITHUB_ENV"
-
-    - name: Check if failure is expected/acceptible
-      if: runner.os == 'Windows' && steps.set_version_cmd.outcome == 'failure'
-      run: printf '%s\n' "$set_version_output" | grep "Bumped version for ci_cd to 0.0.0." | exit 0 || exit 1
-      shell: bash
+      run: python .github/utils/run_hooks.py set-version
+      shell: cmd

--- a/.github/workflows/_local_ci_tests.yml
+++ b/.github/workflows/_local_ci_tests.yml
@@ -92,6 +92,7 @@ jobs:
       run: |
         python -m pip install -U pip
         pip install -U setuptools wheel flit
+        pip install -e .
         pip install -U pre-commit
 
     - name: Run docs-api-reference ('ci-cd create-api-reference-docs')

--- a/.github/workflows/_local_ci_tests.yml
+++ b/.github/workflows/_local_ci_tests.yml
@@ -95,14 +95,133 @@ jobs:
         pip install -e .
         pip install -U pre-commit
 
+    # docs-api-reference
     - name: Run docs-api-reference ('ci-cd create-api-reference-docs')
-      run: pre-commit run -c .github/utils/.pre-commit-config_testing.yaml --all-files --verbose docs-api-reference
+      continue-on-error: true
+      id: docs_api_reference
+      run: |
+        {
+          echo 'docs_api_reference_output<<EOF'
+          pre-commit run -c .github/utils/.pre-commit-config_testing.yaml --all-files --verbose docs-api-reference
+          echo EOF
+        } >> "$GITHUB_ENV"
 
+    - name: Check if failure is expected/acceptible
+      if: steps.docs_api_reference.outcome == 'failure'
+      run: printf '%s\n' "$docs_api_reference_output" | grep "The following files have been changed/added/removed:" | exit 0 || exit 1
+      shell: bash
+
+    - name: Run docs-api-reference ('ci-cd create-api-reference-docs') (cmd)
+      if: runner.os == 'Windows'
+      continue-on-error: true
+      id: docs_api_reference_cmd
+      run: |
+        {
+          echo 'docs_api_reference_output<<EOF'
+          pre-commit run -c .github/utils/.pre-commit-config_testing.yaml --all-files --verbose docs-api-reference
+          echo EOF
+        } >> "$GITHUB_ENV"
+      shell: cmd
+
+    - name: Check if failure is expected/acceptible
+      if: runner.os == 'Windows' && steps.docs_api_reference_cmd.outcome == 'failure'
+      run: printf '%s\n' "$docs_api_reference_output" | grep "The following files have been changed/added/removed:" | exit 0 || exit 1
+      shell: bash
+
+    # docs-landing-page
     - name: Run docs-landing-page ('ci-cd create-docs-index')
-      run: pre-commit run -c .github/utils/.pre-commit-config_testing.yaml --all-files --verbose docs-landing-page || grep "The landing page has been updated." | exit 0 || exit 1
+      continue-on-error: true
+      id: docs_landing_page
+      run: |
+        {
+          echo 'docs_landing_page_output<<EOF'
+          pre-commit run -c .github/utils/.pre-commit-config_testing.yaml --all-files --verbose docs-landing-page
+          echo EOF
+        } >> "$GITHUB_ENV"
 
+    - name: Check if failure is expected/acceptible
+      if: steps.docs_landing_page.outcome == 'failure'
+      run: printf '%s\n' "$docs_landing_page_output" | grep "The landing page has been updated." | exit 0 || exit 1
+      shell: bash
+
+    - name: Run docs-landing-page ('ci-cd create-docs-index') (cmd)
+      if: runner.os == 'Windows'
+      continue-on-error: true
+      id: docs_landing_page_cmd
+      run: |
+        {
+          echo 'docs_landing_page_output<<EOF'
+          pre-commit run -c .github/utils/.pre-commit-config_testing.yaml --all-files --verbose docs-landing-page
+          echo EOF
+        } >> "$GITHUB_ENV"
+      shell: cmd
+
+    - name: Check if failure is expected/acceptible
+      if: runner.os == 'Windows' && steps.docs_landing_page_cmd.outcome == 'failure'
+      run: printf '%s\n' "$docs_landing_page_output" | grep "The landing page has been updated." | exit 0 || exit 1
+      shell: bash
+
+    # update-pyproject
     - name: Run update-pyproject ('ci-cd update-deps')
-      run: pre-commit run -c .github/utils/.pre-commit-config_testing.yaml --all-files --verbose update-pyproject || grep "Successfully updated the following dependencies:" | exit 0 || exit 1
+      continue-on-error: true
+      id: update_pyproject
+      run: |
+        {
+          echo 'update_pyproject_output<<EOF'
+          pre-commit run -c .github/utils/.pre-commit-config_testing.yaml --all-files --verbose update-pyproject
+          echo EOF
+        } >> "$GITHUB_ENV"
 
+    - name: Check if failure is expected/acceptible
+      if: steps.update_pyproject.outcome == 'failure'
+      run: printf '%s\n' "$update_pyproject_output" | grep "Successfully updated the following dependencies:" | exit 0 || exit 1
+      shell: bash
+
+    - name: Run update-pyproject ('ci-cd update-deps') (cmd)
+      if: runner.os == 'Windows'
+      continue-on-error: true
+      id: update_pyproject_cmd
+      run: |
+        {
+          echo 'update_pyproject_output<<EOF'
+          pre-commit run -c .github/utils/.pre-commit-config_testing.yaml --all-files --verbose update-pyproject
+          echo EOF
+        } >> "$GITHUB_ENV"
+      shell: cmd
+
+    - name: Check if failure is expected/acceptible
+      if: runner.os == 'Windows' && steps.update_pyproject_cmd.outcome == 'failure'
+      run: printf '%s\n' "$update_pyproject_output" | grep "Successfully updated the following dependencies:" | exit 0 || exit 1
+      shell: bash
+
+    # set-version
     - name: Run 'ci-cd setver'
-      run: pre-commit run -c .github/utils/.pre-commit-config_testing.yaml --all-files --verbose set-version || grep "Bumped version for ci_cd to 0.0.0." | exit 0 || exit 1
+      continue-on-error: true
+      id: set_version
+      run: |
+        {
+          echo 'set_version_output<<EOF'
+          pre-commit run -c .github/utils/.pre-commit-config_testing.yaml --all-files --verbose set-version
+          echo EOF
+        } >> "$GITHUB_ENV"
+
+    - name: Check if failure is expected/acceptible
+      if: steps.set_version.outcome == 'failure'
+      run: printf '%s\n' "$set_version_output" | grep "Bumped version for ci_cd to 0.0.0." | exit 0 || exit 1
+      shell: bash
+
+    - name: Run 'ci-cd setver' (cmd)
+      if: runner.os == 'Windows'
+      continue-on-error: true
+      id: set_version_cmd
+      run: |
+        {
+          echo 'set_version_output<<EOF'
+          pre-commit run -c .github/utils/.pre-commit-config_testing.yaml --all-files --verbose set-version
+          echo EOF
+        } >> "$GITHUB_ENV"
+
+    - name: Check if failure is expected/acceptible
+      if: runner.os == 'Windows' && steps.set_version_cmd.outcome == 'failure'
+      run: printf '%s\n' "$set_version_output" | grep "Bumped version for ci_cd to 0.0.0." | exit 0 || exit 1
+      shell: bash

--- a/.github/workflows/_local_ci_tests.yml
+++ b/.github/workflows/_local_ci_tests.yml
@@ -67,3 +67,41 @@ jobs:
       with:
         fail_ci_if_error: true
         token: ${{ secrets.CODECOV_TOKEN }}
+
+  # These jobs are mainly to test a default run of the hooks including `--pre-commit`
+  run_hooks:
+    name: Run custom pre-commit hooks
+    runs-on: ${{ matrix.os }}
+
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.7", "3.10"]
+        os: ["ubuntu-latest", "windows-latest"]
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v3
+
+    - name: Set up Python ${{ matrix.python-version}}
+      uses: actions/setup-python@v4
+      with:
+        python-version: ${{ matrix.python-version}}
+
+    - name: Install Python dependencies
+      run: |
+        python -m pip install -U pip
+        pip install -U setuptools wheel flit
+        pip install -U pre-commit
+
+    - name: Run docs-api-reference
+      run: pre-commit run -c .github/utils/.pre-commit-config_testing.yaml --all-files --verbose docs-api-reference
+
+    - name: Run docs-api-reference
+      run: pre-commit run -c .github/utils/.pre-commit-config_testing.yaml --all-files --verbose docs-landing-page
+
+    - name: Run docs-api-reference
+      run: pre-commit run -c .github/utils/.pre-commit-config_testing.yaml --all-files --verbose update-pyproject
+
+    - name: Run docs-api-reference
+      run: pre-commit run -c .github/utils/.pre-commit-config_testing.yaml --all-files --verbose set-version

--- a/.github/workflows/_local_ci_tests.yml
+++ b/.github/workflows/_local_ci_tests.yml
@@ -130,3 +130,8 @@ jobs:
       if: runner.os == 'Windows'
       run: python .github/utils/run_hooks.py set-version
       shell: cmd
+
+    - name: Bare run
+      if: runner.os == 'Windows'
+      run: pre-commit run -c .github/utils/.pre-commit-config_testing.yaml --all-files --verbose docs-api-reference
+      shell: cmd

--- a/.github/workflows/_local_ci_tests.yml
+++ b/.github/workflows/_local_ci_tests.yml
@@ -35,12 +35,13 @@ jobs:
 
   pytest:
     name: pytest
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
 
     strategy:
       fail-fast: false
       matrix:
         python-version: ["3.7", "3.8", "3.9", "3.10"]
+        os: ["ubuntu-latest", "windows-latest"]
 
     steps:
     - name: Checkout repository

--- a/.github/workflows/_local_ci_tests.yml
+++ b/.github/workflows/_local_ci_tests.yml
@@ -105,4 +105,4 @@ jobs:
       run: pre-commit run -c .github/utils/.pre-commit-config_testing.yaml --all-files --verbose update-pyproject || grep "Successfully updated the following dependencies:" | exit 0 || exit 1
 
     - name: Run 'ci-cd setver'
-      run: pre-commit run -c .github/utils/.pre-commit-config_testing.yaml --all-files --verbose set-version
+      run: pre-commit run -c .github/utils/.pre-commit-config_testing.yaml --all-files --verbose set-version || grep "Bumped version for ci_cd to 0.0.0." | exit 0 || exit 1

--- a/.github/workflows/_local_ci_tests.yml
+++ b/.github/workflows/_local_ci_tests.yml
@@ -94,14 +94,14 @@ jobs:
         pip install -U setuptools wheel flit
         pip install -U pre-commit
 
-    - name: Run docs-api-reference
+    - name: Run docs-api-reference ('ci-cd create-api-reference-docs')
       run: pre-commit run -c .github/utils/.pre-commit-config_testing.yaml --all-files --verbose docs-api-reference
 
-    - name: Run docs-api-reference
-      run: pre-commit run -c .github/utils/.pre-commit-config_testing.yaml --all-files --verbose docs-landing-page
+    - name: Run docs-landing-page ('ci-cd create-docs-index')
+      run: pre-commit run -c .github/utils/.pre-commit-config_testing.yaml --all-files --verbose docs-landing-page | exit 0 || grep "The landing page has been updated." | exit 0 || exit 1
 
-    - name: Run docs-api-reference
+    - name: Run update-pyproject ('ci-cd update-deps')
       run: pre-commit run -c .github/utils/.pre-commit-config_testing.yaml --all-files --verbose update-pyproject
 
-    - name: Run docs-api-reference
+    - name: Run 'ci-cd setver'
       run: pre-commit run -c .github/utils/.pre-commit-config_testing.yaml --all-files --verbose set-version

--- a/.github/workflows/_local_ci_tests.yml
+++ b/.github/workflows/_local_ci_tests.yml
@@ -98,10 +98,10 @@ jobs:
       run: pre-commit run -c .github/utils/.pre-commit-config_testing.yaml --all-files --verbose docs-api-reference
 
     - name: Run docs-landing-page ('ci-cd create-docs-index')
-      run: pre-commit run -c .github/utils/.pre-commit-config_testing.yaml --all-files --verbose docs-landing-page | exit 0 || grep "The landing page has been updated." | exit 0 || exit 1
+      run: pre-commit run -c .github/utils/.pre-commit-config_testing.yaml --all-files --verbose docs-landing-page || grep "The landing page has been updated." | exit 0 || exit 1
 
     - name: Run update-pyproject ('ci-cd update-deps')
-      run: pre-commit run -c .github/utils/.pre-commit-config_testing.yaml --all-files --verbose update-pyproject
+      run: pre-commit run -c .github/utils/.pre-commit-config_testing.yaml --all-files --verbose update-pyproject || grep "Successfully updated the following dependencies:" | exit 0 || exit 1
 
     - name: Run 'ci-cd setver'
       run: pre-commit run -c .github/utils/.pre-commit-config_testing.yaml --all-files --verbose set-version

--- a/ci_cd/tasks/api_reference_docs.py
+++ b/ci_cd/tasks/api_reference_docs.py
@@ -295,13 +295,15 @@ special_option: %s""",
                     package.relative_to(root_repo_path) if relative else package.name
                 )
                 py_path = (
-                    f"{py_path_root}/{filename.stem}".replace("/", ".")
+                    f"{py_path_root}/{filename.stem}"
                     if str(relpath) == "."
                     or (str(relpath) == package.name and not single_package)
-                    else f"{py_path_root}/{relpath if single_package else relpath.relative_to(package.name)}/{filename.stem}".replace(
-                        "/", "."
-                    )
+                    else f"{py_path_root}/{relpath if single_package else relpath.relative_to(package.name)}/{filename.stem}"
                 )
+
+                # Cast py_path to Path to ensure correct formatting (forward slashes)
+                py_path = str(Path(py_path)).replace("/", ".")
+
                 LOGGER.debug("filename: %s\npy_path: %s", filename, py_path)
                 if debug:
                     print("filename:", filename, flush=True)

--- a/ci_cd/tasks/api_reference_docs.py
+++ b/ci_cd/tasks/api_reference_docs.py
@@ -301,8 +301,9 @@ special_option: %s""",
                     else f"{py_path_root}/{relpath if single_package else relpath.relative_to(package.name)}/{filename.stem}"
                 )
 
-                # Cast py_path to Path to ensure correct formatting (forward slashes)
-                py_path = str(Path(py_path)).replace("/", ".")
+                # Replace OS specific path separators with forward slashes before
+                # replacing that with dots (for Python import paths).
+                py_path = py_path.replace(os.sep, "/").replace("/", ".")
 
                 LOGGER.debug("filename: %s\npy_path: %s", filename, py_path)
                 if debug:

--- a/ci_cd/tasks/api_reference_docs.py
+++ b/ci_cd/tasks/api_reference_docs.py
@@ -366,22 +366,22 @@ special_option: %s""",
         # Check if there have been any changes.
         # List changes if yes.
 
-        # NOTE: grep returns an exit code of 1 if it doesn't find anything
-        # (which will be good in this case).
-        # Concerning the weird last grep command see:
+        # NOTE: Concerning the weird regular expression, see:
         # http://manpages.ubuntu.com/manpages/precise/en/man1/git-status.1.html
         result = context.run(
             f'git -C "{root_repo_path}" status --porcelain '
-            f"{docs_api_ref_dir.relative_to(root_repo_path)} | "
-            "grep -E '^[? MARC][?MD]' || exit 0",
+            f"{docs_api_ref_dir.relative_to(root_repo_path)}",
             hide=True,
         )
         if result.stdout:
-            sys.exit(
-                f"{Emoji.CURLY_LOOP.value} The following files have been "
-                f"changed/added/removed:\n\n{result.stdout}\nPlease stage them:\n\n"
-                f"  git add {docs_api_ref_dir.relative_to(root_repo_path)}"
-            )
+            for line in result.stdout.splitlines():
+                if re.match(r"^[? MARC][?MD]", line):
+                    sys.exit(
+                        f"{Emoji.CURLY_LOOP.value} The following files have been "
+                        f"changed/added/removed:\n\n{result.stdout}\n"
+                        "Please stage them:\n\n"
+                        f"  git add {docs_api_ref_dir.relative_to(root_repo_path)}"
+                    )
         print(
             f"{Emoji.CHECK_MARK.value} No changes - your API reference documentation "
             "is up-to-date !"

--- a/ci_cd/tasks/api_reference_docs.py
+++ b/ci_cd/tasks/api_reference_docs.py
@@ -321,9 +321,9 @@ special_option: %s""",
                     print("filename:", filename, flush=True)
                     print("py_path:", py_path, flush=True)
 
-                relative_file_path = (
+                relative_file_path = Path(
                     str(filename) if str(relpath) == "." else str(relpath / filename)
-                )
+                ).as_posix()
 
                 # For special files we want to include EVERYTHING, even if it doesn't
                 # have a doc-string

--- a/ci_cd/utils.py
+++ b/ci_cd/utils.py
@@ -2,6 +2,7 @@
 More information on `invoke` can be found at [pyinvoke.org](http://www.pyinvoke.org/).
 """
 import logging
+import platform
 import re
 from enum import Enum
 from pathlib import Path
@@ -17,6 +18,16 @@ LOGGER.setLevel(logging.DEBUG)
 
 class Emoji(str, Enum):
     """Unicode strings for certain emojis."""
+
+    def __new__(cls, value: str) -> "Emoji":
+        obj = str.__new__(cls, value)
+        if platform.system() == "Windows":
+            # Windows does not support unicode emojis, so we replace them with
+            # their corresponding unicode escape sequences
+            obj._value_ = value.encode("unicode_escape").decode("utf-8")
+        else:
+            obj._value_ = value
+        return obj
 
     PARTY_POPPER = "\U0001f389"
     CHECK_MARK = "\u2714"

--- a/tests/tasks/test_api_reference_docs.py
+++ b/tests/tasks/test_api_reference_docs.py
@@ -479,7 +479,7 @@ def test_larger_package(tmp_path: "Path") -> None:
     ]:
         py_path = f"{package_dir.name}." + str(
             module_dir.relative_to(api_reference_folder)
-        ).replace("/", ".")
+        ).replace(os.sep, "/").replace("/", ".")
         assert (module_dir / ".pages").read_text(
             encoding="utf8"
         ) == f'title: "{module_dir.name}"\n', (
@@ -637,7 +637,7 @@ def test_larger_multi_packages(tmp_path: "Path") -> None:
         for module_dir in [package_dir / _ for _ in new_submodules]:
             py_path = f"{package_dir.name}." + str(
                 module_dir.relative_to(package_dir)
-            ).replace("/", ".")
+            ).replace(os.sep, "/").replace("/", ".")
             assert (module_dir / ".pages").read_text(
                 encoding="utf8"
             ) == f'title: "{module_dir.name}"\n', (

--- a/tests/tasks/test_api_reference_docs.py
+++ b/tests/tasks/test_api_reference_docs.py
@@ -2,14 +2,11 @@
 # pylint: disable=too-many-locals
 from typing import TYPE_CHECKING
 
-import pytest
-
 if TYPE_CHECKING:
     from pathlib import Path
 
 
-@pytest.mark.parametrize("pre_commit", [True, False])
-def test_default_run(tmp_path: "Path", pre_commit: bool) -> None:
+def test_default_run(tmp_path: "Path") -> None:
     """Check create_api_reference_docs runs with defaults."""
     import os
     import shutil
@@ -32,7 +29,6 @@ def test_default_run(tmp_path: "Path", pre_commit: bool) -> None:
         MockContext(),
         [str(package_dir.relative_to(tmp_path))],
         root_repo_path=str(tmp_path),
-        pre_commit=pre_commit,
     )
 
     api_reference_folder = docs_folder / "api_reference"

--- a/tests/tasks/test_api_reference_docs.py
+++ b/tests/tasks/test_api_reference_docs.py
@@ -2,11 +2,14 @@
 # pylint: disable=too-many-locals
 from typing import TYPE_CHECKING
 
+import pytest
+
 if TYPE_CHECKING:
     from pathlib import Path
 
 
-def test_default_run(tmp_path: "Path") -> None:
+@pytest.mark.parametrize("pre_commit", [True, False])
+def test_default_run(tmp_path: "Path", pre_commit: bool) -> None:
     """Check create_api_reference_docs runs with defaults."""
     import os
     import shutil
@@ -29,6 +32,7 @@ def test_default_run(tmp_path: "Path") -> None:
         MockContext(),
         [str(package_dir.relative_to(tmp_path))],
         root_repo_path=str(tmp_path),
+        pre_commit=pre_commit,
     )
 
     api_reference_folder = docs_folder / "api_reference"


### PR DESCRIPTION
Remove any OS-specific commands in order to support Windows.

Fixes #160 

Several CI test jobs have been added to run all pre-commit hooks in both Linux and Windows environments, furthermore all pytest jobs have been extended to include Windows environments.

The expanded test-space have revealed some weaknesses regarding path-handling, which have been fixed through the usage of `pathlib.PurePosixPath`. This ensures the user inputs should still match what is explained in the documentation for paths, namely that one should use POSIX (Linux) type path strings (with forward slashes (`/`) and excluding drives and similar).

Finally, any Linux-specific commands used through `invoke.context.run()`, which calls the OS shell, have been removed in favor of a Pythonic approach. **Note**: It is still necessary that the `git` command can be run in the given shell where pre-commit is run.