### PR TITLE
Remove requirement for release to start with 'v'

### DIFF
--- a/.github/workflows/cd_release.yml
+++ b/.github/workflows/cd_release.yml
@@ -147,7 +147,7 @@ on:
 jobs:
   update-and-publish:
     name: Update CHANGELOG and version and publish to PyPI
-    if: startsWith(github.ref, 'refs/tags/v')
+    if: startsWith(github.ref, 'refs/tags/')
     runs-on: ubuntu-latest
 
     steps:
@@ -297,7 +297,7 @@ jobs:
       with:
         user: __token__
         password: ${{ secrets.PyPI_token }}
-        repository_url: https://test.pypi.org/legacy/
+        repository-url: https://test.pypi.org/legacy/
 
     - name: Publish package to PyPI
       if: ( ! inputs.test ) && inputs.publish_on_pypi && inputs.python_package
@@ -369,6 +369,7 @@ jobs:
     - name: Build (& deploy MkDocs) documentation
       run: |
         REF=${{ github.ref }}
+        REF=${REF#refs/tags/}
 
         if [ "${{ inputs.docs_framework }}" == "sphinx" ]; then
           if [[ "${{ inputs.sphinx-build_options }}" =~ \n ]]; then
@@ -385,7 +386,7 @@ jobs:
 
         if [ "${{ inputs.test }}" == "true" ]; then
           if [ "${{ inputs.docs_framework }}" == "mkdocs" ]; then
-            echo "Will here deploy documentation using 'mike', first one called '${REF#refs/tags/v}' with alias 'stable'"
+            echo "Will here deploy documentation using 'mike', first one called '${REF#v}' with alias 'stable'"
             echo "Then one called 'latest' with alias '${{ inputs.release_branch }}'"
           elif [ "${{ inputs.docs_framework }}" == "sphinx" ]; then
             echo "Will here deploy documentation using 'sphinx-build'."
@@ -399,7 +400,7 @@ jobs:
           fi
 
         elif [ "${{ inputs.docs_framework }}" == "mkdocs" ]; then
-          mike deploy --push --remote origin --branch gh-pages --update-aliases --config-file mkdocs.yml ${REF#refs/tags/v} stable
+          mike deploy --push --remote origin --branch gh-pages --update-aliases --config-file mkdocs.yml ${REF#v} stable
           mike deploy --push --remote origin --branch gh-pages --update-aliases --config-file mkdocs.yml latest ${{ inputs.release_branch }}
 
         elif [ "${{ inputs.docs_framework }}" == "sphinx" ]; then

--- a/.github/workflows/cd_release.yml
+++ b/.github/workflows/cd_release.yml
@@ -201,8 +201,7 @@ jobs:
 
     - name: Update version and tag
       run: |
-        REF=${{ github.ref }}
-        REF=${REF#refs/tags/}
+        REF=${GITHUB_REF#refs/tags/}
 
         if [ "${{ inputs.python_package }}" == "true" ]; then
           if [ -z "${{ inputs.package_dirs }}" ]; then
@@ -368,8 +367,7 @@ jobs:
 
     - name: Build (& deploy MkDocs) documentation
       run: |
-        REF=${{ github.ref }}
-        REF=${REF#refs/tags/}
+        REF=${GITHUB_REF#refs/tags/}
 
         if [ "${{ inputs.docs_framework }}" == "sphinx" ]; then
           if [[ "${{ inputs.sphinx-build_options }}" =~ \n ]]; then

--- a/docs/workflows/cd_release.md
+++ b/docs/workflows/cd_release.md
@@ -57,9 +57,11 @@ This workflow should _only_ be used for releasing a single modern Python package
 The repository contains the following:
 
 - (**required**) A Python package root `__init__.py` file with `__version__` defined.
-- (**required**) The workflow is run for a tag that starts with `v` followed by a full semantic version.
-  This will automatically be the case for a GitHub release, which creates a new tag that starts with `v`.
+- (**required**) The workflow is run for a git tag only.
+  This will automatically be the case for a GitHub release.
+  The tag name must be a valid semantic version.
   See [SemVer.org](https://semver.org) for more information about semantic versioning.
+  It is expected, but not required, that the tag name starts with a `v`, e.g., `v1.0.0`.
 
 ## Inputs
 


### PR DESCRIPTION
Fixes #172 

The main requirement is now that the current git ref is a tag and that the tag name is a semantic version.