### PR TITLE
Fix --full-docs-dir regression

### DIFF
--- a/ci_cd/tasks/api_reference_docs.py
+++ b/ci_cd/tasks/api_reference_docs.py
@@ -133,9 +133,9 @@ def create_api_reference_docs(  # pylint: disable=too-many-locals,too-many-branc
 
     # Initialize user-given paths as pure POSIX paths
     package_dir: list[PurePosixPath] = [PurePosixPath(_) for _ in package_dir]
-    root_repo_path: PurePosixPath = PurePosixPath(root_repo_path)  # type: ignore[no-redef]
+    root_repo_path = str(PurePosixPath(root_repo_path))
     docs_folder: PurePosixPath = PurePosixPath(docs_folder)  # type: ignore[no-redef]
-    full_docs_folder: list[PurePosixPath] = [PurePosixPath(_) for _ in full_docs_folder]  # type: ignore[no-redef]
+    full_docs_folder = [Path(PurePosixPath(_)) for _ in full_docs_folder]
 
     def write_file(full_path: Path, content: str) -> None:
         """Write file with `content` to `full_path`"""
@@ -291,7 +291,8 @@ special_option: %s""",
                     # Or filename is in the list of unwanted files:
                     # We don't want it!
                     LOGGER.debug(
-                        "%s is not a Python file or is an unwanted file (through user input). Skipping it.",
+                        "%s is not a Python file or is an unwanted file (through user "
+                        "input). Skipping it.",
                         filename,
                     )
                     if debug:
@@ -330,7 +331,7 @@ special_option: %s""",
                 template = md_template + (
                     no_docstring_template_addition
                     if relative_file_path in full_docs_file
-                    or str(relpath) in full_docs_folder
+                    or relpath in full_docs_folder
                     else ""
                 )
 

--- a/tests/tasks/test_api_reference_docs.py
+++ b/tests/tasks/test_api_reference_docs.py
@@ -177,6 +177,7 @@ def test_special_options(tmp_path: "Path") -> None:
         [str(package_dir.relative_to(tmp_path))],
         root_repo_path=str(tmp_path),
         full_docs_file=["utils.py"],
+        full_docs_folder=["tasks"],
         special_option=[
             'main.py,test_option: "yup"',
             "main.py,another_special_option: true",
@@ -236,16 +237,28 @@ def test_special_options(tmp_path: "Path") -> None:
     ) == 'title: "tasks"\n'
     assert (api_reference_folder / "tasks" / "api_reference_docs.md").read_text(
         encoding="utf8"
-    ) == "# api_reference_docs\n\n::: ci_cd.tasks.api_reference_docs\n"
+    ) == (
+        "# api_reference_docs\n\n::: ci_cd.tasks.api_reference_docs\n    options:\n"
+        "      show_if_no_docstring: true\n"
+    )
     assert (api_reference_folder / "tasks" / "docs_index.md").read_text(
         encoding="utf8"
-    ) == "# docs_index\n\n::: ci_cd.tasks.docs_index\n"
+    ) == (
+        "# docs_index\n\n::: ci_cd.tasks.docs_index\n    options:\n      "
+        "show_if_no_docstring: true\n"
+    )
     assert (api_reference_folder / "tasks" / "setver.md").read_text(
         encoding="utf8"
-    ) == "# setver\n\n::: ci_cd.tasks.setver\n"
+    ) == (
+        "# setver\n\n::: ci_cd.tasks.setver\n    options:\n      "
+        "show_if_no_docstring: true\n"
+    )
     assert (api_reference_folder / "tasks" / "update_deps.md").read_text(
         encoding="utf8"
-    ) == "# update_deps\n\n::: ci_cd.tasks.update_deps\n"
+    ) == (
+        "# update_deps\n\n::: ci_cd.tasks.update_deps\n    options:\n      "
+        "show_if_no_docstring: true\n"
+    )
 
 
 def test_special_options_multiple_packages(tmp_path: "Path") -> None:

--- a/tests/tasks/test_api_reference_docs.py
+++ b/tests/tasks/test_api_reference_docs.py
@@ -290,6 +290,7 @@ def test_special_options_multiple_packages(tmp_path: "Path") -> None:
         [str(package_dir.relative_to(tmp_path)) for package_dir in package_dirs],
         root_repo_path=str(tmp_path),
         full_docs_file=["ci_cd_again/utils.py"],
+        full_docs_folder=["ci_cd_again/tasks"],
         special_option=[
             'ci_cd/main.py,test_option: "yup"',
             "ci_cd/main.py,another_special_option: true",
@@ -379,22 +380,44 @@ def test_special_options_multiple_packages(tmp_path: "Path") -> None:
         ) == 'title: "tasks"\n'
         assert (
             api_reference_folder / package_name / "tasks" / "api_reference_docs.md"
-        ).read_text(
-            encoding="utf8"
-        ) == f"# api_reference_docs\n\n::: {package_name}.tasks.api_reference_docs\n"
+        ).read_text(encoding="utf8") == (
+            f"# api_reference_docs\n\n::: {package_name}.tasks.api_reference_docs\n"
+            + (
+                "    options:\n      show_if_no_docstring: true\n"
+                if package_name == "ci_cd_again"
+                else ""
+            )
+        )
         assert (
             api_reference_folder / package_name / "tasks" / "docs_index.md"
-        ).read_text(
-            encoding="utf8"
-        ) == f"# docs_index\n\n::: {package_name}.tasks.docs_index\n"
+        ).read_text(encoding="utf8") == (
+            f"# docs_index\n\n::: {package_name}.tasks.docs_index\n"
+            + (
+                "    options:\n      show_if_no_docstring: true\n"
+                if package_name == "ci_cd_again"
+                else ""
+            )
+        )
         assert (api_reference_folder / package_name / "tasks" / "setver.md").read_text(
             encoding="utf8"
-        ) == f"# setver\n\n::: {package_name}.tasks.setver\n"
+        ) == (
+            f"# setver\n\n::: {package_name}.tasks.setver\n"
+            + (
+                "    options:\n      show_if_no_docstring: true\n"
+                if package_name == "ci_cd_again"
+                else ""
+            )
+        )
         assert (
             api_reference_folder / package_name / "tasks" / "update_deps.md"
-        ).read_text(
-            encoding="utf8"
-        ) == f"# update_deps\n\n::: {package_name}.tasks.update_deps\n"
+        ).read_text(encoding="utf8") == (
+            f"# update_deps\n\n::: {package_name}.tasks.update_deps\n"
+            + (
+                "    options:\n      show_if_no_docstring: true\n"
+                if package_name == "ci_cd_again"
+                else ""
+            )
+        )
 
 
 def test_larger_package(tmp_path: "Path") -> None:


### PR DESCRIPTION
Try to only use PurePosixPath as a middle stage towards str or Path.

Fixes #174

Test full_docs_folder input:
- Test an individual folder name and that all files in the folder get the special option added.
- Test a subfolder (using POSIX path notation (forward slashes)), ensuring it also works in Windows via the CI tests.
