### PR TITLE
Implement SemanticVersionRange to handle ranges

### DIFF
--- a/ci_cd/utils.py
+++ b/ci_cd/utils.py
@@ -8,8 +8,20 @@ from enum import Enum
 from pathlib import Path
 from typing import TYPE_CHECKING, no_type_check
 
+from pip._vendor.packaging.requirements import InvalidRequirement, Requirement
+from pip._vendor.packaging.specifiers import (
+    InvalidSpecifier,
+    Specifier,
+    SpecifierSet,
+    _IndividualSpecifier,
+)
+
 if TYPE_CHECKING:  # pragma: no cover
-    from typing import Any, Optional, Tuple, Union
+    from typing import Any, Iterator, Optional, Union
+
+    from pip._vendor.packaging.specifiers import LegacySpecifier
+
+    ParsedSpecifier = Union[Specifier, LegacySpecifier]
 
 
 LOGGER = logging.getLogger(__file__)
@@ -124,6 +136,10 @@ class SemanticVersion(str):
         self._pre_release = pre_release if pre_release else None
         self._build = build if build else None
 
+        self._original_version = self._build_version(
+            major, minor, patch, pre_release, build
+        )
+
     @classmethod
     def _build_version(
         cls,
@@ -160,6 +176,21 @@ class SemanticVersion(str):
                 raise ValueError("Patch must be given if build is given")
             version += f"+{build}"
         return version
+
+    @property
+    def original_version(self) -> str:
+        """The original version string used to create the instance."""
+        return self._original_version
+
+    @property
+    def number_of_original_core_version_parts(self) -> int:
+        """The original semantic version parts used to create the instance,
+        ignoring pre-relase and build."""
+        match = re.match(self._REGEX, self.original_version)
+        if match is None:
+            raise AssertionError
+        major, minor, patch, _, _ = match.groups()
+        return len([part for part in (major, minor, patch) if part])
 
     @property
     def major(self) -> int:
@@ -204,19 +235,20 @@ class SemanticVersion(str):
         """Return the string representation of the object."""
         return repr(self.__str__())
 
-    def _validate_other_type(self, other: "Any") -> "SemanticVersion":
+    @classmethod
+    def _validate_other_type(cls, other: "Any") -> "SemanticVersion":
         """Initial check/validation of `other` before rich comparisons."""
         not_implemented_exc = NotImplementedError(
-            f"Rich comparison not implemented between {self.__class__.__name__} and "
+            f"Rich comparison not implemented between {cls.__name__} and "
             f"{type(other)}"
         )
 
-        if isinstance(other, self.__class__):
+        if isinstance(other, cls):
             return other
 
         if isinstance(other, str):
             try:
-                return self.__class__(other)
+                return cls(other)
             except (TypeError, ValueError) as exc:
                 raise not_implemented_exc from exc
 
@@ -224,6 +256,9 @@ class SemanticVersion(str):
 
     def __lt__(self, other: "Any") -> bool:
         """Less than (`<`) rich comparison."""
+        if isinstance(other, SemanticVersionRange):
+            return self < other.lower
+
         other_semver = self._validate_other_type(other)
 
         if self.major < other_semver.major:
@@ -248,6 +283,9 @@ class SemanticVersion(str):
 
     def __eq__(self, other: "Any") -> bool:
         """Equal to (`==`) rich comparison."""
+        if isinstance(other, SemanticVersionRange):
+            return self in other
+
         other_semver = self._validate_other_type(other)
 
         return (
@@ -269,7 +307,7 @@ class SemanticVersion(str):
         """Greater than (`>`) rich comparison."""
         return not self.__le__(other)
 
-    def next_version(self, version_part: str) -> "SemanticVersion":
+    def next_version(self, version_part: "Optional[str]" = None) -> "SemanticVersion":
         """Return the next version for the specified version part.
 
         Parameters:
@@ -282,22 +320,439 @@ class SemanticVersion(str):
             ValueError: If the version part is not one of `major`, `minor`, or `patch`.
 
         """
-        if version_part not in ("major", "minor", "patch"):
+        # Deduce "original_version" for new instance, disregard pre-release and build
+        match = re.match(self._REGEX, self.original_version)
+        if match is None:
+            raise AssertionError
+        _, minor, patch, _, _ = match.groups()
+
+        if not version_part:
+            # Determine what version part to increment based on the original version
+            version_part = "patch" if patch else "minor" if minor else "major"
+
+        if version_part == "major":
+            incremented_version = str(self.major + 1)
+            if minor:
+                incremented_version += ".0"
+            if patch:
+                incremented_version += ".0"
+        elif version_part == "minor":
+            incremented_version = f"{self.major}.{self.minor + 1}"
+            if patch:
+                incremented_version += ".0"
+        elif version_part == "patch":
+            incremented_version = f"{self.major}.{self.minor}.{self.patch + 1}"
+        else:
             raise ValueError(
                 "version_part must be one of 'major', 'minor', or 'patch', not "
                 f"{version_part!r}"
             )
 
-        if version_part == "major":
-            return self.__class__(f"{self.major + 1}.0.0")
-        if version_part == "minor":
-            return self.__class__(f"{self.major}.{self.minor + 1}.0")
+        return self.__class__(incremented_version)
 
-        return self.__class__(f"{self.major}.{self.minor}.{self.patch + 1}")
+
+class SortableSpecifier(Specifier):
+    """A sortable specifier."""
+
+    _sorted_operators = ["===", "==", "~=", ">=", ">", "<", "<=", "!="]
+
+    def __lt__(self, other: "Any") -> bool:
+        """Less than (`<`) rich comparison."""
+        if isinstance(other, _IndividualSpecifier):
+            return self._sorted_operators.index(
+                self.operator
+            ) < self._sorted_operators.index(other.operator)
+        if isinstance(other, str):
+            try:
+                other = self.__class__(other)
+            except InvalidSpecifier as exc:
+                raise NotImplementedError from exc
+            return self._sorted_operators.index(
+                self.operator
+            ) < self._sorted_operators.index(other.operator)
+
+        raise NotImplementedError
+
+
+class SemanticVersionRange:
+    """A range of semantic versions.
+
+    The implementation relies on the pip package `packaging` for parsing the version
+    requirements and checking if a version is in the range.
+    """
+
+    _arbritrary_upper_limit = "9" * 3
+
+    def __init__(self, specifier: "Union[SpecifierSet, Requirement, str]") -> None:
+        if isinstance(specifier, str):
+            try:
+                specifier = Requirement(specifier).specifier
+            except InvalidRequirement:
+                try:
+                    specifier = SpecifierSet(specifier)  # type: ignore[arg-type]
+                except InvalidSpecifier as exc:
+                    raise ValueError(
+                        f"specifier ({specifier}) cannot be parsed as a requirement "
+                        "or specifier set"
+                    ) from exc
+        elif isinstance(specifier, Requirement):
+            specifier = specifier.specifier
+        if not isinstance(specifier, SpecifierSet):
+            raise TypeError(
+                f"specifier must be of type {SpecifierSet.__name__}, "
+                f"{Requirement.__name__}, or str, not {type(specifier).__name__}"
+            )
+
+        self._specifier = self._sanitize_specifier_set(specifier)
+        self._lower = self._determine_lower()
+        self._upper = self._determine_upper()
+
+    def _sanitize_specifier_set(self, specifier_set: "SpecifierSet") -> "SpecifierSet":
+        """Sanitize the specifier set."""
+        if not specifier_set:
+            return specifier_set
+
+        # Check all version specifiers are semantic
+        for specifier in specifier_set:
+            try:
+                SemanticVersion(specifier.version)
+            except ValueError as exc:
+                raise ValueError(
+                    f"Specifier {specifier} is not a semantic version specifier"
+                ) from exc
+
+        # Check single-use operators are used only once
+        if (
+            len(
+                [
+                    specifier
+                    for specifier in specifier_set
+                    if specifier.operator in ("<", "<=")
+                ]
+            )
+            > 1
+        ):
+            raise ValueError(
+                "Multiple upper bound specifiers ('<', '<=') found in specifier set "
+                f"{specifier_set}. Instead, consider using the != operator. For "
+                "example, to avoid a complete minor range: !=1.*"
+            )
+        if (
+            len(
+                [
+                    specifier
+                    for specifier in specifier_set
+                    if specifier.operator in (">", ">=", "~=")
+                ]
+            )
+            > 1
+        ):
+            raise ValueError(
+                "Multiple lower bound specifiers ('>', '>=', '~=') found in specifier "
+                f"set {specifier_set}. Instead, consider using the != operator. For "
+                "example, to avoid a complete minor range: !=1.*"
+            )
+        if (
+            len(
+                [specifier for specifier in specifier_set if specifier.operator == "=="]
+            )
+            > 1
+        ):
+            raise ValueError(
+                "Single-use specifier '==' found multiple times in specifier set "
+                f"{specifier_set}."
+            )
+
+        # Check no other specifiers are given if equals is given
+        if (
+            any(specifier.operator == "==" for specifier in specifier_set)
+            and len(specifier_set) > 1
+        ):
+            raise ValueError(
+                "Specifier set erroneously contains specifiers alongside a '==' "
+                "specifier"
+            )
+
+        # Check that the version range is not "flipped"
+        apparent_range = [None, None]
+        for specifier in specifier_set:
+            if specifier.operator in (">", ">=", "~="):
+                apparent_range[0] = SemanticVersion(specifier.version)
+            elif specifier.operator in ("<", "<="):
+                apparent_range[1] = SemanticVersion(specifier.version)
+            else:
+                continue
+        if (
+            apparent_range[0]
+            and apparent_range[1]
+            and apparent_range[0] > apparent_range[1]
+        ):
+            raise ValueError(
+                f"Version range from specifier set {specifier_set} is 'flipped'. I.e.,"
+                " the apparent lower bound is larger than the apparent upper bound."
+            )
+
+        return specifier_set
+
+    def __contains__(self, version: "str") -> bool:
+        """Check if the given version is in the range."""
+        return version in self._specifier
+
+    def __str__(self) -> str:
+        """Return the string representation of the object."""
+        return str(self._specifier)
+
+    def __repr__(self) -> str:
+        """Return the string representation of the object."""
+        return f"<{self.__class__.__name__}({str(self)!r})>"
+
+    @property
+    def lower(self) -> SemanticVersion:
+        """The lower bound of the range."""
+        return self._lower
+
+    @lower.setter
+    def lower(self, value: "Union[SemanticVersion, str]") -> None:
+        """Set the lower bound of the range."""
+        if isinstance(value, str):
+            value = SemanticVersion(value)
+
+        if not isinstance(value, SemanticVersion):
+            raise TypeError(
+                f"lower must be of type {SemanticVersion.__name__} or str, not "
+                f"{type(value).__name__}"
+            )
+
+        if value > self._upper:
+            raise ValueError(
+                f"lower ({value}) cannot be greater than upper ({self._upper})"
+            )
+        if value not in self and value != SemanticVersion("0"):
+            raise ValueError(
+                f"lower ({value}) is not in the range ({self}) and is not '0'"
+            )
+
+        self._lower = value
+
+    @property
+    def upper(self) -> SemanticVersion:
+        """The upper bound of the range."""
+        return self._upper
+
+    @upper.setter
+    def upper(self, value: "Union[SemanticVersion, str]") -> None:
+        """Set the upper bound of the range."""
+        if isinstance(value, str):
+            value = SemanticVersion(value)
+
+        if not isinstance(value, SemanticVersion):
+            raise TypeError(
+                f"upper must be of type {SemanticVersion.__name__} or str, not "
+                f"{type(value).__name__}"
+            )
+
+        if value < self._lower:
+            raise ValueError(
+                f"upper ({value}) cannot be less than lower ({self._lower})"
+            )
+        if value not in self:
+            raise ValueError(f"upper ({value}) is not in the range ({self})")
+
+        self._upper = value
+
+    @property
+    def operators(self) -> tuple[str, ...]:
+        """The operators used in the specifier."""
+        return tuple(specifier.operator for specifier in self._specifier)
+
+    def version_from_operator(self, operator: str) -> SemanticVersion:
+        """Return the raw string version for the given operator."""
+        for specifier in self._specifier:
+            if specifier.operator == operator:
+                return SemanticVersion(specifier.version)
+        raise ValueError(
+            f"Operator {operator} not found in specifier set {self._specifier}"
+        )
+
+    def _determine_lower(self) -> SemanticVersion:
+        """Determine the lower version range limit based on the specifier."""
+
+        def __next_version(version: SemanticVersion) -> SemanticVersion:
+            """Return the next version of the given version."""
+            if version.patch < int(self._arbritrary_upper_limit):
+                return version.next_version("patch")
+            if version.minor < int(self._arbritrary_upper_limit):
+                return version.next_version("minor")
+            if version.major >= int(self._arbritrary_upper_limit):
+                raise ValueError(
+                    f"Major version for {version} exceeds {self.__class__.__name__}'s "
+                    "internal upper limit"
+                )
+            return version.next_version("major")
+
+        if not self._specifier:
+            return SemanticVersion("0")
+
+        lower = None
+        for specifier in self._specifier:
+            if specifier.operator == ">=":
+                lower = SemanticVersion(specifier.version)
+                break
+            if specifier.operator == "==":
+                lower = SemanticVersion(specifier.version)
+                break
+            if specifier.operator == "~=":
+                lower = SemanticVersion(specifier.version)
+                break
+
+            if specifier.operator == ">":
+                next_version = __next_version(SemanticVersion(specifier.version))
+                while next_version not in self and next_version <= SemanticVersion(
+                    self._arbritrary_upper_limit
+                ):
+                    next_version = __next_version(next_version)
+
+                lower = (
+                    min(SemanticVersion(specifier.version).next_version("patch"), lower)
+                    if lower and lower != SemanticVersion("0")
+                    else SemanticVersion(specifier.version).next_version("patch")
+                )
+            elif specifier.operator in ("<", "<=", "!="):
+                lower = lower or SemanticVersion("0")
+            else:
+                # The arbitrary operator (===) is not supported
+                raise NotImplementedError(
+                    f"Specifier operator {specifier.operator} not implemented"
+                )
+        if lower is None:
+            raise ValueError(f"Could not determine lower bound for {self}")
+        return lower
+
+    def _determine_upper(self) -> SemanticVersion:
+        """Determine the upper version range limit based on the specifier."""
+
+        def __previous_version(version: SemanticVersion) -> SemanticVersion:
+            """Return the previous version of the given version."""
+            if version.patch > 0:
+                return SemanticVersion(
+                    major=version.major, minor=version.minor, patch=version.patch - 1
+                )
+            if version.minor > 0:
+                return SemanticVersion(
+                    major=version.major,
+                    minor=version.minor - 1,
+                    patch=self._arbritrary_upper_limit,
+                )
+            if version.major <= 0:
+                raise ValueError(f"Cannot determine previous version for {version}")
+            return SemanticVersion(
+                major=version.major - 1,
+                minor=self._arbritrary_upper_limit,
+                patch=self._arbritrary_upper_limit,
+            )
+
+        if not self._specifier:
+            # An arbitrary upper limit major version
+            return SemanticVersion(self._arbritrary_upper_limit)
+
+        upper = None
+        for specifier in self._specifier:
+            if specifier.operator == "<=":
+                upper = SemanticVersion(specifier.version)
+                break
+            if specifier.operator == "==":
+                upper = SemanticVersion(specifier.version)
+                break
+
+            if specifier.operator == "<":
+                previous_version = __previous_version(
+                    SemanticVersion(specifier.version)
+                )
+                while (
+                    previous_version not in self
+                    and previous_version != SemanticVersion("0")
+                ):
+                    previous_version = __previous_version(previous_version)
+                upper = (
+                    max(previous_version, upper)
+                    if (
+                        upper and upper != SemanticVersion(self._arbritrary_upper_limit)
+                    )
+                    else previous_version
+                )
+            elif specifier.operator in (">", ">=", "!=", "~="):
+                upper = upper or SemanticVersion(self._arbritrary_upper_limit)
+            else:
+                # The arbitrary operator (===) is not supported
+                raise NotImplementedError(
+                    f"Specifier operator {specifier.operator} not implemented"
+                )
+        if upper is None:
+            raise ValueError(f"Could not determine upper bound for {self}")
+        return upper
+
+    def __gt__(self, other: "Any") -> bool:
+        """Greater than (`>`) rich comparison."""
+        if isinstance(other, self.__class__):
+            other_semver = SemanticVersion(other.upper)
+        else:
+            other_semver = SemanticVersion._validate_other_type(other)
+
+        return self.upper > other_semver
+
+    def __eq__(self, other: "Any") -> bool:
+        """Equal to (`==`) rich comparison."""
+        if isinstance(other, self.__class__):
+            return self._specifier == other._specifier
+
+        other_semver = SemanticVersion._validate_other_type(other)
+
+        return other_semver in self
+
+    def __ne__(self, other: "Any") -> bool:
+        """Not equal to (`!=`) rich comparison."""
+        return not self.__eq__(other)
+
+    def __lt__(self, other: "Any") -> bool:
+        """Less than (`<`) rich comparison."""
+        if isinstance(other, self.__class__):
+            other_semver = SemanticVersion(other.lower)
+        else:
+            other_semver = SemanticVersion._validate_other_type(other)
+
+        return self.lower < other_semver
+
+    def __ge__(self, other: "Any") -> bool:
+        """Greater than or equal to (`>=`) rich comparison."""
+        return not self.__lt__(other)
+
+    def __le__(self, other: "Any") -> bool:
+        """Less than or equal to (`<=`) rich comparison."""
+        return self.__lt__(other) or self.__eq__(other)
+
+    def __and__(self, other: "Any") -> "SemanticVersionRange":
+        """Intersection (`&`) of two version ranges."""
+        if isinstance(other, self.__class__):
+            return self.__class__(str(self) + "," + str(other))
+        if isinstance(other, SemanticVersion):
+            return self.__class__(str(self) + "," + str(other))
+        if isinstance(other, str):
+            return self.__class__(str(self) + "," + other)
+        raise NotImplementedError(
+            f"Intersection between {self.__class__.__name__} and {type(other).__name__} "
+            "not implemented"
+        )
+
+    def __iter__(self) -> "Iterator[SortableSpecifier]":
+        """Iterate over the range, or rather, the underlying SpecifierSet."""
+        return iter(
+            SortableSpecifier(spec=str(_), prereleases=_.prereleases or None)
+            for _ in self._specifier
+        )
 
 
 def update_file(
-    filename: Path, sub_line: "Tuple[str, str]", strip: "Optional[str]" = None
+    filename: Path, sub_line: tuple[str, str], strip: "Optional[str]" = None
 ) -> None:
     """Utility function for tasks to read, update, and write files"""
     if strip is None and filename.suffix == ".md":

--- a/ci_cd/utils.py
+++ b/ci_cd/utils.py
@@ -1,6 +1,8 @@
 """Repository management tasks powered by `invoke`.
 More information on `invoke` can be found at [pyinvoke.org](http://www.pyinvoke.org/).
 """
+from __future__ import annotations
+
 import logging
 import platform
 import re


### PR DESCRIPTION
It builds on the pip Requirement and Specifier classes to deal with version ranges, determining whether a given version is part of it and handling how a set of version specifiers should be updated according to the latest detected version.

Fixes #141 

There's a minor regression, in the sense that non-contiguous version ranges are no longer supported without using `!=` to specify the non-inclusive versions.
This means a version range like `<2,>=3` is not allowed, instead one should do: `!=2.*`.
The change is due to the way the version ranges is implemented - only a single upper and lower bound is allowed per version specifier set. For the disallowed specifier set in the example above there are indeed two distinct ranges: One from v0 to immediately prior to v2, and then another from v3 to infinity. Whereas for the allowed specifier set (which results in the same actual version range) there is only a single lower and upper bound: v0 and infinity, respectively.

In order to be ready for review the following is needed:
- [ ] Possibly more tests for the new class.
- [ ] Check if the "ignore version rules"-implementation can be rewritten using the new class as well as pip Requirement/Specifier/...
- [ ] Update the documentation, specifically with a page about the version update strategy currently "hard-coded" into the logic.