### PR TITLE
Make using dependencies branch toggleable

### DIFF
--- a/.github/workflows/ci_cd_updated_default_branch.yml
+++ b/.github/workflows/ci_cd_updated_default_branch.yml
@@ -26,6 +26,11 @@ on:
         default: false
 
       # Update permanent dependencies branch
+      update_dependencies_branch:
+        description: "Whether or not to update the permanent dependencies branch."
+        required: false
+        type: boolean
+        default: true
       permanent_dependencies_branch:
         description: "The branch name for the permanent dependency updates branch."
         required: false
@@ -414,7 +419,7 @@ jobs:
     name: Update permanent dependencies branch
     runs-on: ubuntu-latest
     needs: deploy_docs
-    if: always()
+    if: always() && inputs.update_dependencies_branch
 
     steps:
     - name: Checkout ${{ github.repository }}

--- a/.github/workflows/ci_check_pyproject_dependencies.yml
+++ b/.github/workflows/ci_check_pyproject_dependencies.yml
@@ -11,8 +11,13 @@ on:
         description: "A git user's email address (used to set the 'user.email' config option)."
         required: true
         type: string
-      permanent_dependencies_branch:
-        description: "The branch name for the permanent dependency updates branch."
+      target_branch:
+        description: "The branch name for the target of the opened PR."
+        required: false
+        type: string
+        # default: "ci/dependency-updates"
+      permanent_dependencies_branch:  # DEPRECATED - v2.6.0 REMOVAL
+        description: "DEPRECATED - use `target_branch` instead. Will be removed in v2.6.0. The branch name for the permanent dependency updates branch."
         required: false
         type: string
         default: "ci/dependency-updates"
@@ -48,7 +53,7 @@ on:
         default: ""
     secrets:
       PAT:
-        description: "A personal access token (PAT) with rights to update the `permanent_dependencies_branch`. This will fallback on `GITHUB_TOKEN`."
+        description: "A personal access token (PAT) with rights to create PRs. This will fallback on `GITHUB_TOKEN`."
         required: false
 
 jobs:
@@ -57,10 +62,16 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - name: Checkout permanent dependencies branch in ${{ github.repository }}
+    - name: Check inputs
+      run: |
+        if [ -n "${{ inputs.permanent_dependencies_branch }}" ]; then
+          echo "::warning file=${{ github.workflow_ref }},title=Deprecation Warning::'permanent_dependencies_branch' is deprecated and will be removed in v2.6.0. Use 'target_branch' instead."
+        fi
+
+    - name: Checkout ${{ inputs.target_branch || inputs.permanent_dependencies_branch }} in ${{ github.repository }}
       uses: actions/checkout@v4
       with:
-        ref: ${{ inputs.permanent_dependencies_branch }}
+        ref: ${{ inputs.target_branch || inputs.permanent_dependencies_branch }}
         fetch-depth: 0
 
     - name: Set up Python ${{ inputs.python_version }}

--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -465,7 +465,7 @@ jobs:
 
         else
           STRICT=
-          echo "::warning file=ci_tests.yml,line=446,col=11,endColumn=18::Beware that the documentation may succeed building, but will not be rendered or built as intended. To ensure this is the case, set 'warnings_as_errors' to 'true' (using '--strict' (MkDocs) or '-W' (Sphinx))."
+          echo "::warning file=ci_tests.yml,line=467,col=11,endColumn=18::Beware that the documentation may succeed building, but will not be rendered or built as intended. To ensure this is the case, set 'warnings_as_errors' to 'true' (using '--strict' (MkDocs) or '-W' (Sphinx))."
         fi
 
         # Run build command

--- a/docs/workflows/ci_cd_updated_default_branch.md
+++ b/docs/workflows/ci_cd_updated_default_branch.md
@@ -46,6 +46,7 @@ Inputs related to updating the permanent dependencies branch.
 
 | **Name** | **Description** | **Required** | **Default** | **Type** |
 |:--- |:--- |:---:|:---:|:---:|
+| `update_dependencies_branch` | Whether or not to update the permanent dependencies branch. | No | `true` | _boolean_ |
 | `permanent_dependencies_branch` | The branch name for the permanent dependency updates branch. | No | ci/dependency-updates | _string_ |
 | `update_dependencies_pr_body_file` | Relative path to a PR body file from the root of the repository, which is used in the 'CI - Update dependencies PR' workflow, if used.</br></br>Example: `'.github/utils/pr_body_update_deps.txt'`. | No | _Empty string_ | _string_ |
 

--- a/docs/workflows/ci_check_pyproject_dependencies.md
+++ b/docs/workflows/ci_check_pyproject_dependencies.md
@@ -58,7 +58,8 @@ The repository contains the following:
 |:--- |:--- |:---:|:---:|:---:|
 | `git_username` | A git username (used to set the 'user.name' config option). | **_Yes_** | | _string_ |
 | `git_email` | A git user's email address (used to set the 'user.email' config option). | **_Yes_** | | _string_ |
-| `permanent_dependencies_branch` | The branch name for the permanent dependency updates branch. | No | ci/dependency-updates | _string_ |
+| `target_branch` | The branch name for the target of the opened PR. | No | _Empty string_ | _string_ |
+| `permanent_dependencies_branch` | **DEPRECATED** - Will be removed in v2.6.0. Use `target_branch` instead.</br></br>The branch name for the permanent dependency updates branch. | No | ci/dependency-updates | _string_ |
 | `python_version` | The Python version to use for the workflow. | No | 3.9 | _string_ |
 | `install_extras` | Any extras to install from the local repository through 'pip'. Must be encapsulated in square parentheses (`[]`) and be separated by commas (`,`) without any spaces.</br></br>Example: `'[dev,release]'`. | No | _Empty string_ | _string_ |
 | `pr_body_file` | Relative path to PR body file from the root of the repository.</br></br>Example: `'.github/utils/pr_body_deps_check.txt'`. | No | _Empty string_ | _string_ |
@@ -93,7 +94,7 @@ jobs:
     with:
       git_username: "Casper Welzel Andersen"
       git_email: "CasperWA@github.com"
-      permanent_dependencies_branch: "ci/dependency-updates"
+      target_branch: "ci/dependency-updates"
       python_version: "3.9"
       install_extras: "[dev]"
       pr_labels: "CI/CD"


### PR DESCRIPTION
Update name for this input in workflow for updating pyproject.toml to be `target_branch`, deprecating `permanent_dependencies_branch`.

Closes #183 