### PR TITLE
Use tomlkit to dump updated dependencies

### DIFF
--- a/ci_cd/tasks/update_deps.py
+++ b/ci_cd/tasks/update_deps.py
@@ -29,7 +29,6 @@ from ci_cd.utils import (
     parse_ignore_entries,
     parse_ignore_rules,
     regenerate_requirement,
-    update_file,
     update_specifier_set,
     warning_msg,
 )
@@ -44,8 +43,44 @@ if TYPE_CHECKING:  # pragma: no cover
 LOGGER = logging.getLogger(__name__)
 
 
+def _update_pyproject(
+    original_dependency: str, updated_dependency: str, pyproject: tomlkit.TOMLDocument
+) -> None:
+    """Update dependencu in pyproject data structure.
+
+    First, check and update the dependency if it is in the "dependencies" group
+    Then, check and update if it is in any of the "optional-dependencies" groups.
+
+    Essentially, we allow for the original dependency to be in multiple groups.
+    """
+    LOGGER.debug(
+        "Updating pyproject data structure for %r to %r",
+        original_dependency,
+        updated_dependency,
+    )
+
+    if original_dependency in pyproject["project"].get("dependencies", []):
+        index = pyproject["project"]["dependencies"].index(original_dependency)
+        pyproject["project"]["dependencies"][index] = updated_dependency.replace(
+            '"', "'"
+        )
+
+    for extra_name, extra_dependencies in (
+        pyproject["project"].get("optional-dependencies", {}).items()
+    ):
+        if original_dependency in extra_dependencies:
+            index = pyproject["project"]["optional-dependencies"][extra_name].index(
+                original_dependency
+            )
+            pyproject["project"]["optional-dependencies"][extra_name][
+                index
+            ] = updated_dependency.replace('"', "'")
+
+
 def _format_and_update_dependency(
-    requirement: Requirement, raw_dependency_line: str, pyproject_path: Path
+    requirement: Requirement,
+    raw_dependency_line: str,
+    pyproject: tomlkit.TOMLDocument = None,
 ) -> None:
     """Regenerate dependency without changing anything but the formatting.
 
@@ -59,12 +94,8 @@ def _format_and_update_dependency(
     )
     LOGGER.debug("Regenerated dependency: %r", updated_dependency)
     if updated_dependency != raw_dependency_line:
-        # Update pyproject.toml since the dependency formatting has changed
-        LOGGER.debug("Updating pyproject.toml for %r", requirement.name)
-        update_file(
-            pyproject_path,
-            (re.escape(raw_dependency_line), updated_dependency.replace('"', "'")),
-        )
+        # Update pyproject data structure since the dependency formatting has changed
+        _update_pyproject(raw_dependency_line, updated_dependency, pyproject)
 
 
 @task(
@@ -174,7 +205,8 @@ def update_deps(  # pylint: disable=too-many-branches,too-many-locals,too-many-s
     already_handled_packages: set[str] = {project_name}
 
     # Build the list of dependencies listed in pyproject.toml
-    dependencies: list[str] = pyproject.get("project", {}).get("dependencies", [])
+    dependencies: list[str] = []
+    dependencies.extend(pyproject.get("project", {}).get("dependencies", []))
     for optional_deps in (
         pyproject.get("project", {}).get("optional-dependencies", {}).values()
     ):
@@ -214,9 +246,7 @@ def update_deps(  # pylint: disable=too-many-branches,too-many-locals,too-many-s
             LOGGER.info(msg)
             print(info_msg(msg), flush=True)
 
-            _format_and_update_dependency(
-                parsed_requirement, dependency, pyproject_path
-            )
+            _format_and_update_dependency(parsed_requirement, dependency, pyproject)
             already_handled_packages.add(parsed_requirement)
             continue
 
@@ -233,9 +263,7 @@ def update_deps(  # pylint: disable=too-many-branches,too-many-locals,too-many-s
                 LOGGER.warning(msg)
                 print(warning_msg(msg), flush=True)
 
-            _format_and_update_dependency(
-                parsed_requirement, dependency, pyproject_path
-            )
+            _format_and_update_dependency(parsed_requirement, dependency, pyproject)
             already_handled_packages.add(parsed_requirement)
             continue
 
@@ -408,14 +436,8 @@ def update_deps(  # pylint: disable=too-many-branches,too-many-locals,too-many-s
             )
             LOGGER.debug("Updated dependency: %r", updated_dependency)
 
-            pattern_sub_line = re.escape(dependency)
-            replacement_sub_line = updated_dependency.replace('"', "'")
+            _update_pyproject(dependency, updated_dependency, pyproject)
 
-            LOGGER.debug("pattern_sub_line: %s", pattern_sub_line)
-            LOGGER.debug("replacement_sub_line: %s", replacement_sub_line)
-
-            # Update pyproject.toml
-            update_file(pyproject_path, (pattern_sub_line, replacement_sub_line))
             already_handled_packages.add(parsed_requirement)
             updated_packages[parsed_requirement.name] = ",".join(
                 str(_)
@@ -430,6 +452,9 @@ def update_deps(  # pylint: disable=too-many-branches,too-many-locals,too-many-s
         sys.exit(
             f"{Emoji.CROSS_MARK.value} Errors occurred! See printed statements above."
         )
+
+    # Update pyproject.toml
+    pyproject_path.write_text(tomlkit.dumps(pyproject), encoding="utf-8")
 
     if updated_packages:
         print(


### PR DESCRIPTION
Closes #203 

Add a new utility function to update the parsed `pyproject.toml` file in-memory document, which will eventually be dumped (using `tomlkit`) and written to (overwriting) the `pyproject.toml` file.
This let's `tomlkit` handle the serialization (converting the parsed file back to TOML-syntax) and should be more stable than the current implementation using regular expressions.

As a side note, this now _only_ writes to/updates the `pyproject.toml` file once - at the end of going through all dependencies _if_ no errors occurred.
This is an (improved) change from the existing behaviour, which writes to/updates the `pyproject.toml` file for each dependency (if necessary) and **does not** revert changes if an error occurs. The improvement I see here, is that the `pyproject.toml` file now is _only_ changed if there were no errors, plus the disk is touched only once for writing.