### PR TITLE
Use non-deprecated actions inputs

### DIFF
--- a/.github/workflows/cd_release.yml
+++ b/.github/workflows/cd_release.yml
@@ -270,7 +270,7 @@ jobs:
       with:
         token: ${{ secrets.PAT || secrets.GITHUB_TOKEN }}
         branch: ${{ inputs.release_branch }}
-        sleep: 15
+        pre_sleep: 15
         force: true
         tags: true
         unprotect_reviews: true
@@ -299,7 +299,7 @@ jobs:
 
     - name: Publish package to TestPyPI
       if: inputs.test && inputs.publish_on_pypi && inputs.python_package
-      uses: pypa/gh-action-pypi-publish@v1.8.10
+      uses: pypa/gh-action-pypi-publish@release/v1
       with:
         user: __token__
         password: ${{ secrets.PyPI_token }}
@@ -307,7 +307,7 @@ jobs:
 
     - name: Publish package to PyPI
       if: ( ! inputs.test ) && inputs.publish_on_pypi && inputs.python_package
-      uses: pypa/gh-action-pypi-publish@v1.8.10
+      uses: pypa/gh-action-pypi-publish@release/v1
       with:
         user: __token__
         password: ${{ secrets.PyPI_token }}

--- a/.github/workflows/ci_automerge_prs.yml
+++ b/.github/workflows/ci_automerge_prs.yml
@@ -67,7 +67,7 @@ jobs:
       with:
         token: ${{ secrets.PAT || secrets.GITHUB_TOKEN }}
         branch: ${{ github.event.pull_request.head.ref }}
-        sleep: 15
+        pre_sleep: 15
         unprotect_reviews: true
 
     - name: Activate auto-merge

--- a/.github/workflows/ci_cd_updated_default_branch.yml
+++ b/.github/workflows/ci_cd_updated_default_branch.yml
@@ -330,7 +330,7 @@ jobs:
       with:
         token: ${{ secrets.PAT || secrets.GITHUB_TOKEN }}
         branch: ${{ inputs.default_repo_branch }}
-        sleep: 15
+        pre_sleep: 15
         force: true
         tags: true
         unprotect_reviews: true
@@ -472,5 +472,5 @@ jobs:
       with:
         token: ${{ secrets.PAT || secrets.GITHUB_TOKEN }}
         branch: ${{ inputs.permanent_dependencies_branch }}
-        sleep: 15
+        pre_sleep: 15
         force: ${{ env.FORCE_PUSH }}


### PR DESCRIPTION
Implements the following updates:
- Use `pre_sleep` in push-protected action
- Use `release/v1` version for gh-action-pypi-publish action.

Closes #216.