### PR TITLE
Utilize `packaging.version.Version`

### DIFF
--- a/ci_cd/tasks/update_deps.py
+++ b/ci_cd/tasks/update_deps.py
@@ -15,6 +15,7 @@ import tomlkit
 from invoke import task
 from packaging.markers import default_environment
 from packaging.requirements import InvalidRequirement, Requirement
+from packaging.version import VERSION_PATTERN
 from tomlkit.exceptions import TOMLKitError
 
 from ci_cd.exceptions import InputError, UnableToResolve
@@ -42,6 +43,18 @@ if TYPE_CHECKING:  # pragma: no cover
 
 # Get logger
 LOGGER = logging.getLogger(__name__)
+
+
+VALID_PACKAGE_NAME_PATTERN = r"^([A-Z0-9]|[A-Z0-9][A-Z0-9._-]*[A-Z0-9])$"
+"""
+Pattern to validate package names.
+
+This is a valid non-normalized name, i.e., it can contain capital letters and
+underscores, periods, and multiples of these, including minus characters.
+
+See PEP 508 for more information, as well as the packaging documentation:
+https://packaging.python.org/en/latest/specifications/name-normalization/
+"""
 
 
 def _format_and_update_dependency(
@@ -268,9 +281,8 @@ def update_deps(  # pylint: disable=too-many-branches,too-many-locals,too-many-s
             hide=True,
         )
         package_latest_version_line = out.stdout.split(sep="\n", maxsplit=1)[0]
-        match = re.match(
-            r"(?P<package>[a-zA-Z0-9-_]+) \((?P<version>[0-9]+(?:\.[0-9]+){0,2})\)",
-            package_latest_version_line,
+        match = re.search(
+            r"(?P<package>\S+) \((?P<version>\S+)\)", package_latest_version_line
         )
         if match is None:
             msg = (

--- a/ci_cd/utils/versions.py
+++ b/ci_cd/utils/versions.py
@@ -129,6 +129,9 @@ class SemanticVersion(str):
                     self._regex, ".".join(str(_) for _ in _python_version.release)
                 )
                 if match is None:
+                    # This should not really be possible at this point, as the
+                    # Version.releasethis is a guaranteed match.
+                    # But we keep it here for sanity's sake.
                     raise ValueError(
                         f"version ({version}) cannot be parsed as a semantic version "
                         "according to the SemVer.org regular expression"
@@ -254,6 +257,8 @@ class SemanticVersion(str):
 
     def __str__(self) -> str:
         """Return the full version."""
+        if self.python_version:
+            return str(self.as_python_version())
         return (
             f"{self.major}.{self.minor}.{self.patch}"
             f"{f'-{self.pre_release}' if self.pre_release else ''}"
@@ -262,6 +267,8 @@ class SemanticVersion(str):
 
     def __repr__(self) -> str:
         """Return the string representation of the object."""
+        if self.python_version:
+            return repr(str(self.as_python_version()))
         return repr(self.__str__())
 
     def _validate_other_type(self, other: "Any") -> "SemanticVersion":

--- a/ci_cd/utils/versions.py
+++ b/ci_cd/utils/versions.py
@@ -123,6 +123,7 @@ class SemanticVersion(str):
                         "according to the SemVer.org regular expression"
                     ) from exc
 
+                # Success. Now let's redo the SemVer.org regular expression match
                 self._python_version = _python_version
                 match = re.match(
                     self._regex, ".".join(str(_) for _ in _python_version.release)
@@ -218,7 +219,8 @@ class SemanticVersion(str):
         """Return the Python version as defined by `packaging.version.Version`."""
         if self.python_version:
             # If the SemanticVersion was generated from a Version, return the original
-            # epoch (and the rest, if the release equals the current shortened version)
+            # epoch (and the rest, if the release equals the current version).
+            # Otherwise, return it as a "base_version".
 
             # epoch
             redone_version = (
@@ -230,20 +232,20 @@ class SemanticVersion(str):
             # release
             redone_version += self.shortened()
 
-            if self.shortened() == ".".join(
-                str(_) for _ in self.python_version.release
-            ):
+            if (self.major, self.minor, self.patch)[
+                : len(self.python_version.release)
+            ] == self.python_version.release:
                 # pre, post, dev, local
-                if self.python_version.pre:
-                    redone_version += "".join(self.python_version.pre)
+                if self.python_version.pre is not None:
+                    redone_version += "".join(str(_) for _ in self.python_version.pre)
 
-                if self.python_version.post:
+                if self.python_version.post is not None:
                     redone_version += f".post{self.python_version.post}"
 
-                if self.python_version.dev:
+                if self.python_version.dev is not None:
                     redone_version += f".dev{self.python_version.dev}"
 
-                if self.python_version.local:
+                if self.python_version.local is not None:
                     redone_version += f"+{self.python_version.local}"
 
             return Version(redone_version)

--- a/ci_cd/utils/versions.py
+++ b/ci_cd/utils/versions.py
@@ -218,7 +218,7 @@ class SemanticVersion(str):
         """The Python version as defined by `packaging.version.Version`."""
         return self._python_version
 
-    def as_python_version(self) -> Version:
+    def as_python_version(self, shortened: bool = True) -> Version:
         """Return the Python version as defined by `packaging.version.Version`."""
         if self.python_version:
             # If the SemanticVersion was generated from a Version, return the original
@@ -233,7 +233,12 @@ class SemanticVersion(str):
             )
 
             # release
-            redone_version += self.shortened()
+            if shortened:
+                redone_version += self.shortened()
+            else:
+                redone_version += ".".join(
+                    str(_) for _ in (self.major, self.minor, self.patch)
+                )
 
             if (self.major, self.minor, self.patch)[
                 : len(self.python_version.release)
@@ -258,7 +263,7 @@ class SemanticVersion(str):
     def __str__(self) -> str:
         """Return the full version."""
         if self.python_version:
-            return str(self.as_python_version())
+            return str(self.as_python_version(shortened=False))
         return (
             f"{self.major}.{self.minor}.{self.patch}"
             f"{f'-{self.pre_release}' if self.pre_release else ''}"
@@ -267,9 +272,7 @@ class SemanticVersion(str):
 
     def __repr__(self) -> str:
         """Return the string representation of the object."""
-        if self.python_version:
-            return repr(str(self.as_python_version()))
-        return repr(self.__str__())
+        return f"{self.__class__.__name__}({self.__str__()!r})"
 
     def _validate_other_type(self, other: "Any") -> "SemanticVersion":
         """Initial check/validation of `other` before rich comparisons."""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -83,8 +83,5 @@ max-returns = 10
 
 [tool.pytest.ini_options]
 minversion = "7.0"
-filterwarnings = [
-    "ignore:.*imp module.*:DeprecationWarning",
-    # Remove when invoke updates to `inspect.signature()` or similar:
-    "ignore:.*inspect.getargspec().*:DeprecationWarning",
-]
+addopts = ["-rs", "--cov=ci_cd", "--cov-report=term-missing"]
+filterwarnings = ["error"]

--- a/tests/tasks/test_update_deps.py
+++ b/tests/tasks/test_update_deps.py
@@ -21,7 +21,7 @@ def test_update_deps(tmp_path: "Path", caplog: pytest.LogCaptureFixture) -> None
     original_dependencies = {
         "invoke": "1.7",
         "tomlkit": "0.11.4",
-        "mike": "1.1",
+        "mike": "1!1.1",
         "pytest": "7.1",
         "pytest-cov": "3.0",
         "pre-commit": "2.20",
@@ -42,14 +42,14 @@ dependencies = [
 
 [project.optional-dependencies]
 docs = [
-    "mike >={original_dependencies['mike']},<3",
+    "mike >={original_dependencies['mike']},<1!3",
 ]
 testing = [
     "pytest ~={original_dependencies['pytest']}",
     "pytest-cov ~={original_dependencies['pytest-cov']},!=3.1",
 ]
 dev = [
-    "mike >={original_dependencies['mike']},<3",
+    "mike >={original_dependencies['mike']},<1!3",
     "pre-commit~={original_dependencies['pre-commit']}",
     # "pylint ~={original_dependencies['pylint']},!=2.14.*",
     "test[testing]",
@@ -124,14 +124,14 @@ dependencies = [
 
 [project.optional-dependencies]
 docs = [
-    "mike >={original_dependencies['mike']},<3",
+    "mike >={original_dependencies['mike']},<1!3",
 ]
 testing = [
     "pytest ~={original_dependencies['pytest']}",
     "pytest-cov ~=3.1,!=3.1",
 ]
 dev = [
-    "mike >=1!{original_dependencies['mike']},<3",
+    "mike >={original_dependencies['mike']},<1!3",
     "pre-commit~=2.21",
     # "pylint ~={original_dependencies['pylint']},!=2.14.*",
     "test[testing]",

--- a/tests/tasks/test_update_deps.py
+++ b/tests/tasks/test_update_deps.py
@@ -47,13 +47,21 @@ docs = [
 testing = [
     "pytest ~={original_dependencies['pytest']}",
     "pytest-cov ~={original_dependencies['pytest-cov']},!=3.1",
-    "test-name <=1!3,!=2.0.1",
+    "test-pkg <=1!3,!=1!2.0.1",
 ]
 dev = [
     "mike >={original_dependencies['mike']},<1!3",
     "pre-commit~={original_dependencies['pre-commit']}",
     # "pylint ~={original_dependencies['pylint']},!=2.14.*",
     "test[testing]",
+]
+
+# Test epochs
+epoch = [
+    "epoch>=2!1.2,<2!2",
+    "epoch1~=2023.1.1",
+    "epoch2~=1!1.0",
+    "epoch3~=1!1.0.1",
 ]
 
 # List from https://peps.python.org/pep-0508/#complete-grammar
@@ -96,7 +104,11 @@ pep_508 = [
                 re.compile(r".*A.B-C_D$"): "A.B-C_D (1.2.3)",
                 re.compile(r".*aa$"): "aa (1.2.3)",
                 re.compile(r".*name$"): "name (1.2.3)",
-                re.compile(r".*name$"): "test-name (1!2.3)",
+                re.compile(r".*test-pkg$"): "test-pkg (1!2.3)",
+                re.compile(r".*epoch$"): "epoch (2!2.0.4.post1)",
+                re.compile(r".*epoch1$"): "epoch1 (1!1.0.0)",
+                re.compile(r".*epoch2$"): "epoch2 (1!2.1.0)",
+                re.compile(r".*epoch3$"): "epoch3 (1!1.1.0.post1)",
             },
             **{re.compile(rf".*name{i}$"): f"name{i} (3.2.1)" for i in range(1, 12)},
         }
@@ -131,13 +143,21 @@ docs = [
 testing = [
     "pytest ~={original_dependencies['pytest']}",
     "pytest-cov ~=3.1,!=3.1",
-    "test-name <=1!3,!=2.0.1",
+    "test-pkg <=1!3,!=1!2.0.1",
 ]
 dev = [
     "mike >={original_dependencies['mike']},<1!3",
     "pre-commit~=2.21",
     # "pylint ~={original_dependencies['pylint']},!=2.14.*",
     "test[testing]",
+]
+
+# Test epochs
+epoch = [
+    "epoch>=2!1.2,<2!3",
+    "epoch1~=2023.1.1,==1!1.0.0",
+    "epoch2>=1!1.0.0,<1!3",
+    "epoch3~=1!1.1.0",
 ]
 
 # List from https://peps.python.org/pep-0508/#complete-grammar

--- a/tests/tasks/test_update_deps.py
+++ b/tests/tasks/test_update_deps.py
@@ -84,9 +84,9 @@ pep_508 = [
     context = MockContext(
         run={
             **{
-                re.compile(r".*invoke$"): "invoke (1.7.1)\n",
+                re.compile(r".*invoke$"): "invoke (1.7.1.post1)\n",
                 re.compile(r".*tomlkit$"): "tomlkit (1.0.0)",
-                re.compile(r".*mike$"): "mike (1.1.1)",
+                re.compile(r".*mike$"): "mike (1!1.1.1)",
                 re.compile(r".*pytest$"): "pytest (7.1.0)",
                 re.compile(r".*pytest-cov$"): "pytest-cov (3.1.5)",
                 re.compile(r".*pre-commit$"): "pre-commit (2.21.5)",
@@ -131,7 +131,7 @@ testing = [
     "pytest-cov ~=3.1,!=3.1",
 ]
 dev = [
-    "mike >={original_dependencies['mike']},<3",
+    "mike >=1!{original_dependencies['mike']},<3",
     "pre-commit~=2.21",
     # "pylint ~={original_dependencies['pylint']},!=2.14.*",
     "test[testing]",

--- a/tests/tasks/test_update_deps.py
+++ b/tests/tasks/test_update_deps.py
@@ -47,6 +47,7 @@ docs = [
 testing = [
     "pytest ~={original_dependencies['pytest']}",
     "pytest-cov ~={original_dependencies['pytest-cov']},!=3.1",
+    "test-name <=1!3,!=2.0.1",
 ]
 dev = [
     "mike >={original_dependencies['mike']},<1!3",
@@ -95,6 +96,7 @@ pep_508 = [
                 re.compile(r".*A.B-C_D$"): "A.B-C_D (1.2.3)",
                 re.compile(r".*aa$"): "aa (1.2.3)",
                 re.compile(r".*name$"): "name (1.2.3)",
+                re.compile(r".*name$"): "test-name (1!2.3)",
             },
             **{re.compile(rf".*name{i}$"): f"name{i} (3.2.1)" for i in range(1, 12)},
         }
@@ -129,6 +131,7 @@ docs = [
 testing = [
     "pytest ~={original_dependencies['pytest']}",
     "pytest-cov ~=3.1,!=3.1",
+    "test-name <=1!3,!=2.0.1",
 ]
 dev = [
     "mike >={original_dependencies['mike']},<1!3",

--- a/tests/utils/test_versions.py
+++ b/tests/utils/test_versions.py
@@ -252,7 +252,8 @@ def test_semanticversion_python_version(
         if isinstance(version_, Version) or (
             isinstance(version_, str)
             and re.match(
-                SemanticVersion._regex, version_  # pylint: disable=protected-access
+                SemanticVersion._semver_regex,  # pylint: disable=protected-access
+                version_,
             )
             is None
         ):

--- a/tests/utils/test_versions.py
+++ b/tests/utils/test_versions.py
@@ -201,6 +201,53 @@ def test_semanticversion_next_version_invalid() -> None:
             SemanticVersion("1.0.0").next_version(version_part)
 
 
+@pytest.mark.parametrize(
+    "version",
+    [
+        "1.dev0",
+        "1.0.dev456",
+        "1.0a1",
+        "1.0a2.dev456",
+        "1.0a12.dev456",
+        "1.0a12",
+        "1.0b1.dev456",
+        "1.0b2",
+        "1.0b2.post345.dev456",
+        "1.0b2.post345",
+        "1.0rc1.dev456",
+        "1.0rc1",
+        "1.0.post456.dev34",
+        "1.0.post456",
+        "1.1.dev1",
+    ],
+)
+def test_semanticversion_python_version(version: str) -> None:
+    """Test the python_version method of SemanticVersion class.
+    This includes checking parsing PEP 440 valid versions.
+    """
+    from packaging.version import Version
+
+    from ci_cd.utils.versions import SemanticVersion
+
+    for version_ in (version, Version(version)):
+        semver = SemanticVersion(version_)
+        assert semver
+        assert (
+            semver.python_version == Version(version_)
+            if isinstance(version_, str)
+            else version_
+        ), f"Failed for version: {version_}, type: {type(version_)}"
+        assert (
+            semver.as_python_version() == Version(version_)
+            if isinstance(version_, str)
+            else version_
+        ), (
+            f"Failed for version: {version_}, type: {type(version_)}, "
+            f"as_python_version: {semver.as_python_version()}, Version(): "
+            f"{Version(version_) if isinstance(version_, str) else version_}"
+        )
+
+
 def _parametrize_ignore_version() -> (
     "dict[str, tuple[str, str, IgnoreVersions, IgnoreUpdateTypes, bool]]"
 ):

--- a/tests/utils/test_versions.py
+++ b/tests/utils/test_versions.py
@@ -86,17 +86,19 @@ def test_semanticversion() -> None:
             "1.0.0-rc.1+exp.sha.5114f85",
         ),
     ]
-    assert all(
-        SemanticVersion(**input_[0]) == input_[1]
-        if isinstance(input_, tuple)
-        else isinstance(SemanticVersion(input_), SemanticVersion)
-        for input_ in valid_inputs
-    )
-    assert all(
-        isinstance(SemanticVersion(version=input_), SemanticVersion)
-        for input_ in valid_inputs
-        if isinstance(input_, str)
-    )
+    for input_ in valid_inputs:
+        value = (
+            SemanticVersion(**input_[0]) == input_[1]
+            if isinstance(input_, tuple)
+            else isinstance(SemanticVersion(input_), SemanticVersion)
+        )
+        assert value, f"Failed for input: {input_}. SemanticVersion: {value}"
+
+    for input_ in valid_inputs:
+        if isinstance(input_, str):
+            assert isinstance(
+                SemanticVersion(version=input_), SemanticVersion
+            ), f"Failed for input: {input_}"
 
 
 def test_semanticversion_invalid() -> None:


### PR DESCRIPTION
Fixes #221 

Since we are currently only supporting Python packages, it makes sense to use the [`packaging.version.Version`](https://packaging.python.org/en/latest/specifications/version-specifiers/#version-scheme) class to parse the latest retrieved version from PyPI. This ensures we can handle the quirks of Python versions.

Addresses the **bold** parts of #217, and the immediate bug there.

Specifically, this addresses the `epoch` and `post-release` segments, adding tests for these as well.

For now, all non `base_version` segments are stripped from the version, meaning only epoch (if present) + release (major.minor.patch) are included from a parsed `Version` instance.

Extra logic is needed to handle and support the remaining `Version` segments, as is also mentioned in #217.