### PR TITLE
Use git add -- . instead of git commit -a

### DIFF
--- a/.github/workflows/cd_release.yml
+++ b/.github/workflows/cd_release.yml
@@ -249,7 +249,8 @@ jobs:
           done
         fi
 
-        git commit -am "Release ${REF} - Changelog"
+        git add -- .
+        git commit -m "Release ${REF} - Changelog"
 
         if [ -z "${{ inputs.tag_message_file }}" ] || [ ! -f "${{ inputs.tag_message_file }}" ]; then
           TAG_MSG_FILE=.tmp_tag-msg_${{ github.run_id }}_${{ github.run_number }}_${{ github.run_attempt }}.txt

--- a/.github/workflows/ci_automerge_prs.yml
+++ b/.github/workflows/ci_automerge_prs.yml
@@ -59,7 +59,8 @@ jobs:
         git config --global user.name "${{ inputs.git_username }}"
         git config --global user.email "${{ inputs.git_email }}"
 
-        git commit -am "Auto-merge extra changes."
+        git add -- .
+        git commit -m "Auto-merge extra changes."
 
     - name: Push changes to '${{ github.event.pull_request.head.ref }}'
       if: inputs.perform_changes

--- a/.github/workflows/ci_update_dependencies.yml
+++ b/.github/workflows/ci_update_dependencies.yml
@@ -123,7 +123,8 @@ jobs:
       if: inputs.update_pre-commit
       run: |
         if [ "${UPDATED_PRE_COMMIT_HOOKS}" == "true" ]; then
-          git commit -am "Update \`pre-commit\` hooks"
+          git add -- .
+          git commit -m "Update \`pre-commit\` hooks"
         fi
 
     - name: Set PR body


### PR DESCRIPTION
Fixes #236 

Every case of `git commit -a` usage has been split into a prior line of `git add -- .` before then committing to ensure the intended result happens, which is to commit _all_ changes, be they changed files, new additions or even deletions (although the last here should not actually happen).