### PR TITLE
Push for PyPI Trusted Publisher usage

### DIFF
--- a/.github/workflows/_local_cd_release.yml
+++ b/.github/workflows/_local_cd_release.yml
@@ -11,14 +11,16 @@ jobs:
     if: github.repository == 'SINTEF/ci-cd' && startsWith(github.ref, 'refs/tags/v')
     uses: ./.github/workflows/cd_release.yml
     with:
+      # General
       git_username: "TEAM 4.0[bot]"
       git_email: "TEAM4.0@SINTEF.no"
+      release_branch: main
+
+      # Distribution
       python_package: true
       publish_on_pypi: false
+      upload_distribution: false
       package_dirs: ci_cd
-      release_branch: main
-      update_docs: true
-      doc_extras: "[docs]"
       changelog_exclude_tags_regex: "^v[0-9]+$"  # Exclude 'v1' tag
       test: false
       version_update_changes_separator: ","
@@ -39,5 +41,10 @@ jobs:
         .github/workflows/ci_check_pyproject_dependencies.yml,https://github\.com/SINTEF/ci-cd\.git@v[0-9]+.*$,https://github.com/SINTEF/ci-cd.git@v{version}
         docs/workflows/cd_release.md,\(https://github\.com/SINTEF/ci-cd/blob/v[0-9]+.*/\.github/workflows/_local_cd_release\.yml\),(https://github.com/SINTEF/ci-cd/blob/v{version}/.github/workflows/_local_cd_release.yml)
         .github/workflows/ci_tests.yml,https://github\.com/SINTEF/ci-cd\.git@v[0-9]+.*$,https://github.com/SINTEF/ci-cd.git@v{version}
+
+      # Documentation
+      update_docs: true
+      doc_extras: "[docs]"
+
     secrets:
       PAT: ${{ secrets.RELEASE_PAT }}

--- a/.github/workflows/cd_release.yml
+++ b/.github/workflows/cd_release.yml
@@ -36,6 +36,11 @@ on:
         default: false
 
       # Update Python package version, build and release on PyPI
+      publish_on_pypi:
+        description: "Whether or not to publish on PyPI. **Note**: This is only relevant if 'python_package' is 'true', which is the default."
+        required: true
+        type: boolean
+        default: false
       python_package:
         description: "Whether or not this is a Python package, where the version should be updated in the 'package_dir'/__init__.py for the possibly several 'package_dir' lines given in the 'package_dirs' input and a build and release to PyPI should be performed."
         required: false
@@ -67,10 +72,15 @@ on:
         type: string
         default: ""
       build_cmd:
-        description: "The package build command, e.g., `'flit build'` or `'python -m build'` (default)."
+        description: "The package build command, e.g., `'flit build'` or `'python -m build'`."
         required: false
         type: string
-        default: "python -m build"
+        default: "python -m build --outdir dist ."
+      build_dir:
+        description: "The directory where the built distribution is located. This should reflect the directory used in the build command or by default by the build library."
+        required: false
+        type: string
+        default: "dist"
       tag_message_file:
         description: "Relative path to a release tag message file from the root of the repository. Example: `'.github/utils/release_tag_msg.txt'`."
         required: false
@@ -86,8 +96,8 @@ on:
         required: false
         type: string
         default: ""
-      publish_on_pypi:
-        description: "Whether or not to publish on PyPI. **Note**: This is only relevant if 'python_package' is 'true', which is the default."
+      upload_distribution:
+        description: "Whether or not to upload the built distribution as an artifact. **Note**: This is only relevant if 'python_package' is 'true', which is the default."
         required: false
         type: boolean
         default: true
@@ -316,6 +326,15 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.PAT || secrets.GITHUB_TOKEN }}
 
+    - name: Upload source distribution
+      if: inputs.upload_distribution && inputs.python_package
+      uses: actions/upload-artifact@v4
+      with:
+        name: dist
+        path: ${{ inputs.build_dir }}
+        if-no-files-found: error
+        overwrite: true
+
     - name: Publish package to TestPyPI
       if: inputs.test && inputs.publish_on_pypi && inputs.python_package
       uses: pypa/gh-action-pypi-publish@release/v1
@@ -323,6 +342,7 @@ jobs:
         user: __token__
         password: ${{ secrets.PyPI_token }}
         repository-url: https://test.pypi.org/legacy/
+        packages-dir: ${{ inputs.build_dir }}
 
     - name: Publish package to PyPI
       if: ( ! inputs.test ) && inputs.publish_on_pypi && inputs.python_package
@@ -330,6 +350,7 @@ jobs:
       with:
         user: __token__
         password: ${{ secrets.PyPI_token }}
+        packages-dir: ${{ inputs.build_dir }}
 
   docs:
     name: Deploy release documentation

--- a/docs/index.md
+++ b/docs/index.md
@@ -2,6 +2,15 @@
 
 **Current version to use:** `v2.7.4`
 
+!!! warning "Important"
+    The default for `publish_on_pypi` in the [_CD - Release_ workflow](./workflows/cd_release.md) has changed from `true` to `false` in version `2.8.0`.
+
+    To keep using the previous behaviour, set `publish_on_pypi: true` in the workflow file.
+
+    This change has been introduced to push for the use of PyPI's [Trusted Publisher](https://docs.pypi.org/trusted-publishers/) feature, which is not yet supported by reusable/callable workflows.
+
+    See the [Using PyPI's Trusted Publisher](./workflows/cd_release.md#using-pypis-trusted-publisher) section for more information on how to migrate to this feature.
+
 Use tried and tested continuous integration (CI) and continuous deployment (CD) tools from this repository.
 
 Currently, the repository offers GitHub Actions callable/reusable workflows and [pre-commit](https://pre-commit.com) hooks.


### PR DESCRIPTION
Closes #180 

[Trusted Publisher](https://docs.pypi.org/trusted-publishers/) is a feature from PyPI that is [currently not supported from reusable/callable workflows](https://github.com/marketplace/actions/pypi-publish#trusted-publishing).

To workaround this fact, the _CD - Release_ workflow has been modified in two ways:
1. The default for `publish_on_pypi` has been changed to `false`.
2. A new step for uploading the built distribution files as a [GitHub artifact](https://docs.github.com/en/actions/using-workflows/storing-workflow-data-as-artifacts) has been added, with an input toggle `upload_distribution` that defaults to `true`.

To support the latter, a new `build_dir` input has been added, which specifies the build target folder for the distribution. It should match either the custom output folder expressed in the `build_cmd` input or the default build directory for the chosen build library.

In an attempt to combat users that rely on default values of `publish_on_pypi`, the input has been made a required input.
Hopefully, this has the effect that for workflows, where it has not been specified explicitly, any runs using the latest version will fail, prompting users to check the documentation, where an informational admonition has been placed front and center on the landing page, as well as at the top of the _CD - Release_-specific documentation page.

Note, the status of "required" for `publish_on_pypi` will only last for the next minor version release (expected to be v2.8).

The _CD - Release_-specific documentation page has had a new section added to it, regarding how one can utilize the workflow as well as implement PyPI's Trusted Publisher feature.

---

Example of the warning on the landing page that will be introduced by this PR:
![image](https://github.com/user-attachments/assets/61e6dbc1-e605-40ad-8c77-232a04d075da)
