### PR TITLE
Remove support for Python 3.7

### DIFF
--- a/.github/workflows/_local_ci_tests.yml
+++ b/.github/workflows/_local_ci_tests.yml
@@ -43,7 +43,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]
         os: ["ubuntu-latest", "windows-latest"]
 
     steps:
@@ -81,7 +81,7 @@ jobs:
       fail-fast: false
       matrix:
         # Use lowest and highest supported (stable) Python version
-        python-version: ["3.7", "3.12"]
+        python-version: ["3.8", "3.12"]
         os: ["ubuntu-latest", "windows-latest"]
 
     steps:

--- a/.github/workflows/cd_release.yml
+++ b/.github/workflows/cd_release.yml
@@ -185,9 +185,9 @@ jobs:
     steps:
     - name: Validate inputs
       run: |
-        if [[ ! "${{ inputs.python_version_build }}" =~ ^3\.([7-9]|1[0-4])(\..*)?$ ]]; then
+        if [[ ! "${{ inputs.python_version_build }}" =~ ^3\.([8-9]|1[0-4])(\..*)?$ ]]; then
           echo "Python version '${{ inputs.python_version_build }}' is not supported."
-          echo "Supported versions are: 3.7, 3.8, 3.9, 3.10, 3.11, 3.12, 3.13, 3.14."
+          echo "Supported versions are: 3.8, 3.9, 3.10, 3.11, 3.12, 3.13, 3.14."
           exit 1
         fi
 

--- a/.github/workflows/ci_cd_updated_default_branch.yml
+++ b/.github/workflows/ci_cd_updated_default_branch.yml
@@ -208,9 +208,9 @@ jobs:
             exit 1
         fi
 
-        if [[ ! "${{ inputs.python_version }}" =~ ^3\.([7-9]|1[0-4])(\..*)?$ ]]; then
+        if [[ ! "${{ inputs.python_version }}" =~ ^3\.([8-9]|1[0-4])(\..*)?$ ]]; then
           echo "Python version '${{ inputs.python_version }}' is not supported."
-          echo "Supported versions are: 3.7, 3.8, 3.9, 3.10, 3.11, 3.12, 3.13, 3.14."
+          echo "Supported versions are: 3.8, 3.9, 3.10, 3.11, 3.12, 3.13, 3.14."
           exit 1
         fi
 

--- a/.github/workflows/ci_check_pyproject_dependencies.yml
+++ b/.github/workflows/ci_check_pyproject_dependencies.yml
@@ -98,9 +98,9 @@ jobs:
     - name: Validate inputs
       id: validate_inputs
       run: |
-        if [[ ! "${{ inputs.python_version }}" =~ ^3\.([7-9]|1[0-4])(\..*)?$ ]]; then
+        if [[ ! "${{ inputs.python_version }}" =~ ^3\.([8-9]|1[0-4])(\..*)?$ ]]; then
           echo "Python version '${{ inputs.python_version }}' is not supported."
-          echo "Supported versions are: 3.7, 3.8, 3.9, 3.10, 3.11, 3.12, 3.13, 3.14."
+          echo "Supported versions are: 3.8, 3.9, 3.10, 3.11, 3.12, 3.13, 3.14."
           exit 1
         fi
 

--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -405,9 +405,9 @@ jobs:
 
     - name: Validate inputs
       run: |
-        if [[ "${{ steps.determine_framework.outputs.framework }}" == "mkdocs" && ! "${{ inputs.python_version_docs }}" =~ ^3\.([7-9]|1[0-4])(\..*)?$ ]]; then
+        if [[ "${{ steps.determine_framework.outputs.framework }}" == "mkdocs" && ! "${{ inputs.python_version_docs }}" =~ ^3\.([8-9]|1[0-4])(\..*)?$ ]]; then
           echo "Python version '${{ inputs.python_version_docs }}' is not supported."
-          echo "Supported versions are: 3.7, 3.8, 3.9, 3.10, 3.11, 3.12, 3.13, 3.14."
+          echo "Supported versions are: 3.8, 3.9, 3.10, 3.11, 3.12, 3.13, 3.14."
           exit 1
         fi
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,3 @@
-# To install the git pre-commit hook run:
-#   pre-commit install
 default_language_version:
   python: python3.9
 
@@ -23,12 +21,11 @@ repos:
   # the language
   # It works on files in-place
   - repo: https://github.com/asottile/pyupgrade
-    # Latest version for Python 3.7: 3.3.2
     # Latest version for Python 3.8: 3.8.0
     rev: v3.19.1
     hooks:
     - id: pyupgrade
-      args: [--py37-plus]
+      args: [--py38-plus]
 
   # Black is a code style and formatter
   # It works on files in-place

--- a/docs/workflows/ci_tests.md
+++ b/docs/workflows/ci_tests.md
@@ -180,7 +180,7 @@ jobs:
     uses: SINTEF/ci-cd/.github/workflows/ci_tests.yml@v2.8.3
     with:
       python_version_pylint_safety: "3.8"
-      python_version_docs: "3.7"
+      python_version_docs: "3.9"
       install_extras: "[dev,docs]"
       skip_pre-commit_hooks: pylint
       pylint_options: --rcfile=pyproject.toml
@@ -208,7 +208,7 @@ jobs:
     uses: SINTEF/ci-cd/.github/workflows/ci_tests.yml@v2.8.3
     with:
       python_version_pylint_safety: "3.8"
-      python_version_docs: "3.7"
+      python_version_docs: "3.9"
       install_extras: "[dev,docs]"
       skip_pre-commit_hooks: pylint
       pylint_runs: |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,6 @@ classifiers = [
     "Development Status :: 2 - Pre-Alpha",
     "License :: OSI Approved :: MIT License",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.7",
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
@@ -29,34 +28,30 @@ classifiers = [
     "Private :: Do Not Upload",
 ]
 keywords = ["ci", "cd", "pre-commit"]
-requires-python = "~=3.7"
+requires-python = "~=3.8"
 dynamic = ["version", "description"]
 
 dependencies = [
     "invoke ~=2.2",
-    "packaging ~=24.0",
-    "tomlkit ~=0.12.5",
-    "typing-extensions ~=4.7; python_version < '3.8'",
-    "typing-extensions ~=4.12; python_version >= '3.8'",
+    "packaging ~=24.2",
+    "tomlkit ~=0.13.2",
+    "typing-extensions ~=4.12",
 ]
 
 [project.optional-dependencies]
 docs = [
     "mike ~=2.1",
-    "mkdocs ~=1.5",
+    "mkdocs ~=1.6",
     "mkdocs-awesome-pages-plugin ~=2.9",
-    "mkdocs-material ~=9.2; python_version < '3.8'",
-    "mkdocs-material ~=9.5; python_version >= '3.8'",
-    "mkdocstrings[python-legacy] ~=0.22.0; python_version < '3.8'",
-    "mkdocstrings[python-legacy] ~=0.26.1; python_version >= '3.8'",
+    "mkdocs-material ~=9.5",
+    "mkdocstrings[python-legacy] ~=0.26.1",
 ]
 testing = [
-    "pytest ~=7.4",
-    "pytest-cov ~=4.1",
+    "pytest ~=8.3",
+    "pytest-cov ~=5.0",
 ]
 dev = [
-    "pre-commit ~=2.21; python_version < '3.8'",
-    "pre-commit ~=3.5; python_version >= '3.8'",
+    "pre-commit ~=3.5",
     "ci-cd[docs,testing]",
 ]
 
@@ -71,7 +66,7 @@ Changelog = "https://SINTEF.github.io/ci-cd/latest/CHANGELOG"
 "ci-cd" = "ci_cd.main:program.run"
 
 [tool.mypy]
-python_version = "3.7"
+python_version = "3.8"
 ignore_missing_imports = true
 scripts_are_modules = true
 warn_unused_configs = true
@@ -80,7 +75,7 @@ allow_redefinition = true
 check_untyped_defs = true
 
 [tool.pytest.ini_options]
-minversion = "7.4"
+minversion = "8.3"
 addopts = ["-rs", "--cov=ci_cd", "--cov-report=term-missing:skip-covered"]
 filterwarnings = ["error"]
 

--- a/tests/tasks/test_update_deps.py
+++ b/tests/tasks/test_update_deps.py
@@ -33,7 +33,7 @@ def test_update_deps(tmp_path: Path, caplog: pytest.LogCaptureFixture) -> None:
         data=f"""
 [project]
 name = "test"
-requires-python = "~=3.7"
+requires-python = "~=3.8"
 
 dependencies = [
     "invoke ~={original_dependencies['invoke']}",
@@ -127,7 +127,7 @@ pep_508 = [
     expected_updated_pyproject_file = f"""
 [project]
 name = "test"
-requires-python = "~=3.7"
+requires-python = "~=3.8"
 
 dependencies = [
     "invoke ~={original_dependencies['invoke']}",
@@ -353,7 +353,7 @@ def test_ignore_rules_logic(
         data="""
 [project]
 name = "test"
-requires-python = "~=3.7"
+requires-python = "~=3.8"
 
 dependencies = [
     "invoke ~=1.7",
@@ -641,7 +641,7 @@ def test_non_parseable_pyproject_toml(tmp_path: Path) -> None:
 
 @pytest.mark.parametrize(
     "requires_python",
-    ["", 'requires-python = "invalid"', 'requires-python = "3.7"'],
+    ["", 'requires-python = "invalid"', 'requires-python = "3.8"'],
     ids=["missing", "invalid", "missing operator"],
 )
 def test_no_requires_python_in_pyproject_toml(
@@ -681,7 +681,7 @@ def test_missing_project_package_name(tmp_path: Path) -> None:
     pyproject_file.write_text(
         data="""
 [project]
-requires-python = "~=3.7"
+requires-python = "~=3.8"
 """,
         encoding="utf8",
     )


### PR DESCRIPTION
## Copilot summary

This pull request includes multiple changes to update the supported Python versions across various configuration files and scripts. The most important changes involve removing support for Python 3.7 and ensuring compatibility with Python 3.8 and higher.

### Updates to supported Python versions:

* [`.github/workflows/_local_ci_tests.yml`](diffhunk://#diff-7fc1532738f8260483e85ff06836034911bec73a37e58d590919939842f6a178L46-R46): Removed Python 3.7 from the matrix of supported Python versions. [[1]](diffhunk://#diff-7fc1532738f8260483e85ff06836034911bec73a37e58d590919939842f6a178L46-R46) [[2]](diffhunk://#diff-7fc1532738f8260483e85ff06836034911bec73a37e58d590919939842f6a178L84-R84)
* [`.github/workflows/cd_release.yml`](diffhunk://#diff-596559b1f8b64fb202104da87bab57ea30a0902451ca9cba6826485bf30976cdL188-R190): Updated the validation logic to exclude Python 3.7 and updated the list of supported versions.
* [`.github/workflows/ci_cd_updated_default_branch.yml`](diffhunk://#diff-48ffda662186d491e260e89b9b0d08d8720f250aad19c4a608fb1726b32b849aL211-R213): Updated the validation logic to exclude Python 3.7 and updated the list of supported versions.
* [`.github/workflows/ci_check_pyproject_dependencies.yml`](diffhunk://#diff-dab4bfe6270c1f0c15b06189050533293385217dd922b331adba968901bbcb47L101-R103): Updated the validation logic to exclude Python 3.7 and updated the list of supported versions.
* [`.github/workflows/ci_tests.yml`](diffhunk://#diff-bf607a21ebbd18b3f436cc9fac6937d9c8839c33ae022cb29c2bddd873f470ebL408-R410): Updated the validation logic to exclude Python 3.7 and updated the list of supported versions.
* [`.pre-commit-config.yaml`](diffhunk://#diff-63a9c44a44acf85fea213a857769990937107cf072831e1a26808cfde9d096b9L1-L2): Removed references to Python 3.7 and updated the `pyupgrade` hook to use `--py38-plus`. [[1]](diffhunk://#diff-63a9c44a44acf85fea213a857769990937107cf072831e1a26808cfde9d096b9L1-L2) [[2]](diffhunk://#diff-63a9c44a44acf85fea213a857769990937107cf072831e1a26808cfde9d096b9L26-R28)
* [`docs/workflows/ci_tests.md`](diffhunk://#diff-dac04e2f09680363faa0b47df29d1dedf883d554cbcdd9bdc21c1a64fc32bfb9L183-R183): Updated the example Python versions to exclude Python 3.7 and use Python 3.9 for documentation. [[1]](diffhunk://#diff-dac04e2f09680363faa0b47df29d1dedf883d554cbcdd9bdc21c1a64fc32bfb9L183-R183) [[2]](diffhunk://#diff-dac04e2f09680363faa0b47df29d1dedf883d554cbcdd9bdc21c1a64fc32bfb9L211-R211)
* [`pyproject.toml`](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L19): Removed Python 3.7 from the classifiers and updated the `requires-python` field to `~=3.8`. Updated dependencies and tools to be compatible with Python 3.8 and higher. [[1]](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L19) [[2]](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L32-R54) [[3]](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L74-R69) [[4]](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L83-R78)
* [`tests/tasks/test_update_deps.py`](diffhunk://#diff-6ad7a19ed56d379b1f141414d60ca62c4f275c89492b93a47d6c6003d282b49fL36-R36): Updated test cases to use Python 3.8 instead of Python 3.7. [[1]](diffhunk://#diff-6ad7a19ed56d379b1f141414d60ca62c4f275c89492b93a47d6c6003d282b49fL36-R36) [[2]](diffhunk://#diff-6ad7a19ed56d379b1f141414d60ca62c4f275c89492b93a47d6c6003d282b49fL130-R130) [[3]](diffhunk://#diff-6ad7a19ed56d379b1f141414d60ca62c4f275c89492b93a47d6c6003d282b49fL356-R356) [[4]](diffhunk://#diff-6ad7a19ed56d379b1f141414d60ca62c4f275c89492b93a47d6c6003d282b49fL644-R644) [[5]](diffhunk://#diff-6ad7a19ed56d379b1f141414d60ca62c4f275c89492b93a47d6c6003d282b49fL684-R684)