### PR TITLE
Make sure to instantiate str variable before adding to it

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -21,7 +21,6 @@ repos:
   # the language
   # It works on files in-place
   - repo: https://github.com/asottile/pyupgrade
-    # Latest version for Python 3.8: 3.8.0
     rev: v3.19.1
     hooks:
     - id: pyupgrade

--- a/ci_cd/tasks/setver.py
+++ b/ci_cd/tasks/setver.py
@@ -203,13 +203,15 @@ replacement (handled): %s
         try:
             update_file(filepath, (pattern, replacement))
         except re.error as exc:
+            msg = ""
+
             if validated_code_base_updates[0] != (
                 filepath,
                 pattern,
                 replacement,
                 input_replacement,
             ):
-                msg = "Some files have already been updated !\n\n "
+                msg += "Some files have already been updated !\n\n "
 
             msg += (
                 f"Could not update file {filepath} according to the given input:\n\n  "

--- a/tests/tasks/test_setver.py
+++ b/tests/tasks/test_setver.py
@@ -365,7 +365,8 @@ def test_init_file_not_found() -> None:
 
 @pytest.mark.parametrize("fail_fast", [True, False])
 def test_invalid_code_base_update(fail_fast: bool) -> None:
-    """Test setver emits an error and stops when given an invalid code_base_update."""
+    """Test setver emits an error and stops when given an invalid code_base_update
+    concerning the splitter."""
     from invoke import MockContext
 
     from ci_cd.tasks.setver import setver
@@ -405,5 +406,38 @@ def test_invalid_code_base_filepaths(fail_fast: bool) -> None:
             package_dir="does not matter",
             version="0.1.0",
             code_base_update=["invalid,invalid,invalid again"],
+            fail_fast=fail_fast,
+        )
+
+
+@pytest.mark.parametrize("fail_fast", [True, False])
+def test_invalid_code_base_update_regex(fail_fast: bool, tmp_path: Path) -> None:
+    """Test setver emits an error and stops when given invalid regex in
+    code_base_update."""
+    from invoke import MockContext
+
+    from ci_cd.tasks.setver import setver
+
+    # No matter fail_fast, the error message will be the same, since this happens after
+    # the logic of failing fast. Here we just fail.
+    error_msg = "Could not update file"
+
+    # Create __init__.py file
+    package_dir = tmp_path / "src" / "my_package"
+    package_dir.mkdir(parents=True)
+    (package_dir / "__init__.py").write_text("__version__ = '0.0.0'\n")
+
+    # Create a file to update
+    file_to_update = package_dir / "file_to_update"
+    file_to_update.write_text("version = '0.0.0'\n")
+
+    with pytest.raises(SystemExit, match=error_msg):
+        # Here the regex is invalid because the first parenthesis is being escaped
+        setver(
+            MockContext(),
+            package_dir="does not matter",
+            version="0.1.0",
+            code_base_update=[rf"{file_to_update.resolve()},\(?:'|\"),{{version}}"],
+            code_base_update_separator=",",
             fail_fast=fail_fast,
         )


### PR DESCRIPTION
Fixes #322 

## AI Summary

This pull request includes updates to the `.pre-commit-config.yaml` file and improvements to error handling in the `setver.py` script.

Configuration updates:

* [`.pre-commit-config.yaml`](diffhunk://#diff-63a9c44a44acf85fea213a857769990937107cf072831e1a26808cfde9d096b9L24): Removed a comment about the latest version for Python 3.8 for the `pyupgrade` repository.

Error handling improvements:

* [`ci_cd/tasks/setver.py`](diffhunk://#diff-2bf6471803f2fb044447086394d8f93a86a1f0106ece506c39814738fef48829R206-R214): Enhanced the error message construction by initializing the `msg` variable as an empty string and appending additional information conditionally.