### PR TITLE
Deprecate the pylint+safety CI tests job

### DIFF
--- a/.github/workflows/_local_ci_tests.yml
+++ b/.github/workflows/_local_ci_tests.yml
@@ -17,14 +17,7 @@ jobs:
 
       # pylint & safety
       run_pylint: false
-
-      run_safety: true
-      # ID: 70612
-      #   Package: Jinja2
-      #   Has been disputed by the maintainer and multiple third parties.
-      #   For more information see: https://github.com/advisories/GHSA-f6pv-j8mr-w6rr
-      safety_options: |
-        --ignore=70612
+      run_safety: false
 
       # build dist
       build_libs: flit

--- a/.github/workflows/_local_ci_tests.yml
+++ b/.github/workflows/_local_ci_tests.yml
@@ -17,7 +17,7 @@ jobs:
 
       # pylint & safety
       run_pylint: false
-      run_safety: false
+      run_safety: true
 
       # build dist
       build_libs: flit

--- a/.github/workflows/_local_ci_tests.yml
+++ b/.github/workflows/_local_ci_tests.yml
@@ -17,7 +17,7 @@ jobs:
 
       # pylint & safety
       run_pylint: false
-      run_safety: true
+      run_safety: false
 
       # build dist
       build_libs: flit

--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -68,7 +68,7 @@ on:
         description: "Run the `pylint` test job."
         required: false
         type: boolean
-        default: true
+        default: false
       pylint_options:
         description: "Single (space-separated) or multi-line string of pylint command line options. Note, this is only valid if 'pylint_runs' is not defined."
         required: false
@@ -89,7 +89,7 @@ on:
         description: "Run the `safety` test job."
         required: false
         type: boolean
-        default: true
+        default: false
       safety_options:
         description: "Single (space-separated) or multi-line string of safety command line options."
         required: false

--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -294,6 +294,11 @@ jobs:
     runs-on: ${{ inputs.runner }}
 
     steps:
+    - name: This job is deprecated
+      run: |
+        echo "This job is deprecated. See https://sintef.github.io/ci-cd/latest/workflows/ci_tests/#run-pylint-safety"
+        echo "::warning file=ci_tests.yml,line=299,col=9::The 'pylint_and_safety' job is deprecated. See https://sintef.github.io/ci-cd/latest/workflows/ci_tests/#run-pylint-safety"
+
     - name: Checkout ${{ github.repository }}
       uses: actions/checkout@v4
       with:

--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -297,7 +297,7 @@ jobs:
     - name: This job is deprecated
       run: |
         echo "This job is deprecated. See https://sintef.github.io/ci-cd/latest/workflows/ci_tests/#run-pylint-safety"
-        echo "::warning file=ci_tests.yml,line=299,col=9::The 'pylint_and_safety' job is deprecated. See https://sintef.github.io/ci-cd/latest/workflows/ci_tests/#run-pylint-safety"
+        echo "::warning file=ci_tests.yml,line=299,col=9::The 'Run `pylint` & `safety`' job is deprecated. See https://sintef.github.io/ci-cd/latest/workflows/ci_tests/#run-pylint-safety"
 
     - name: Checkout ${{ github.repository }}
       uses: actions/checkout@v4

--- a/docs/workflows/ci_tests.md
+++ b/docs/workflows/ci_tests.md
@@ -46,6 +46,10 @@ This job **should not be run** _if_ the repository does not implement `pre-commi
 
 ### Run `pylint` & `safety`
 
+!!! warning "Deprecation notice"
+    The `pylint` and `safety` jobs are deprecated in favor of using [`pre-commit`](https://pre-commit.com) hooks and the dedicated [safety GitHub Action](https://docs.safetycli.com/safety-docs/installation/github-actions).
+    This job will be removed in a future version.
+
 Run the [`pylint`](https://pylint.pycqa.org/) and/or [`safety`](https://github.com/pyupio/safety) tools.
 
 The `pylint` tool can be run in different ways.
@@ -66,8 +70,8 @@ There are no expectations or pre-requisites.
 
 | **Name** | **Description** | **Required** | **Default** | **Type** |
 |:--- |:--- |:---:|:---:|:---:|
-| `run_pylint` | Run the `pylint` test job. | No | `true` | _boolean_ |
-| `run_safety` | Run the `safety` test job. | No | `true` | _boolean_ |
+| `run_pylint` | Run the `pylint` test job. | No | `false` | _boolean_ |
+| `run_safety` | Run the `safety` test job. | No | `false` | _boolean_ |
 | `python_version_pylint_safety` | The Python version to use for the `pylint` and `safety` test jobs. | No | 3.9 | _string_ |
 | `pip_index_url_pylint_safety` | A URL to a PyPI repository index. | No | `https://pypi.org/simple/` | _string_ |
 | `pip_extra_index_urls_pylint_safety` | A space-delimited string of URLs to additional PyPI repository indices. | No | _Empty string_ | _string_ |
@@ -237,15 +241,15 @@ See also [General information](index.md#general-information).
 | `pip_index_url_pre-commit` | A URL to a PyPI repository index. | No | `https://pypi.org/simple/` | _string_ |
 | `pip_extra_index_urls_pre-commit` | A space-delimited string of URLs to additional PyPI repository indices. | No | _Empty string_ | _string_ |
 | `skip_pre-commit_hooks` | A comma-separated list of pre-commit hook IDs to skip when running `pre-commit` after updating hooks. | No | _Empty string_ | _string_ |
-| `run_pylint` | Run the `pylint` test job. | No | `true` | _boolean_ |
-| `run_safety` | Run the `safety` test job. | No | `true` | _boolean_ |
-| `python_version_pylint_safety` | The Python version to use for the `pylint` and `safety` test jobs. | No | 3.9 | _string_ |
-| `pip_index_url_pylint_safety` | A URL to a PyPI repository index. | No | `https://pypi.org/simple/` | _string_ |
-| `pip_extra_index_urls_pylint_safety` | A space-delimited string of URLs to additional PyPI repository indices. | No | _Empty string_ | _string_ |
-| `pylint_targets` | Space-separated string of pylint file and folder targets.</br></br>**Note**: This is only valid if `pylint_runs` is not defined. | **Yes, if `pylint_runs` is not defined** | _Empty string_ | _string_ |
-| `pylint_options` | Single (space-separated) or multi-line string of pylint command line options.</br></br>**Note**: This is only valid if `pylint_runs` is not defined. | No | _Empty string_ | _string_ |
-| `pylint_runs` | Single or multi-line string with each line representing a separate pylint run/execution. This should include all desired options and targets.</br></br>**Important**: The inputs `pylint_options` and `pylint_targets` will be ignored if this is defined. | No | _Empty string_ | _string_ |
-| `safety_options` | Single (space-separated) or multi-line string of safety command line options. | No | _Empty string_ | _string_ |
+| `run_pylint` | **_Deprecated_** Run the `pylint` test job. | No | `false` | _boolean_ |
+| `run_safety` | **_Deprecated_** Run the `safety` test job. | No | `false` | _boolean_ |
+| `python_version_pylint_safety` | **_Deprecated_** The Python version to use for the `pylint` and `safety` test jobs. | No | 3.9 | _string_ |
+| `pip_index_url_pylint_safety` | **_Deprecated_** A URL to a PyPI repository index. | No | `https://pypi.org/simple/` | _string_ |
+| `pip_extra_index_urls_pylint_safety` | **_Deprecated_** A space-delimited string of URLs to additional PyPI repository indices. | No | _Empty string_ | _string_ |
+| `pylint_targets` | **_Deprecated_** Space-separated string of pylint file and folder targets.</br></br>**Note**: This is only valid if `pylint_runs` is not defined. | **Yes, if `pylint_runs` is not defined** | _Empty string_ | _string_ |
+| `pylint_options` | **_Deprecated_** Single (space-separated) or multi-line string of pylint command line options.</br></br>**Note**: This is only valid if `pylint_runs` is not defined. | No | _Empty string_ | _string_ |
+| `pylint_runs` | **_Deprecated_** Single or multi-line string with each line representing a separate pylint run/execution. This should include all desired options and targets.</br></br>**Important**: The inputs `pylint_options` and `pylint_targets` will be ignored if this is defined. | No | _Empty string_ | _string_ |
+| `safety_options` | **_Deprecated_** Single (space-separated) or multi-line string of safety command line options. | No | _Empty string_ | _string_ |
 | `run_build_package` | Run the `build package` test job. | No | `true` | _boolean_ |
 | `python_version_package` | The Python version to use for the `build package` test job. | No | 3.9 | _string_ |
 | `pip_index_url_package` | A URL to a PyPI repository index. | No | `https://pypi.org/simple/` | _string_ |


### PR DESCRIPTION
The latest safety CLI has a dedicated GitHub Action one can use instead (the 'safety check' has been deprecated and 'safety scan' requires a user).
Pylint is not longer being used in general in favor of ruff.

## AI Summary

This pull request deprecates the `pylint` and `safety` jobs in favor of using `pre-commit` hooks and a dedicated GitHub Action for `safety`. It updates configuration files and documentation to reflect this change, including setting the default values for these jobs to `false` and marking related inputs as deprecated.

### Deprecation of `pylint` and `safety` jobs:

* [`.github/workflows/_local_ci_tests.yml`](diffhunk://#diff-7fc1532738f8260483e85ff06836034911bec73a37e58d590919939842f6a178L20-R20): Disabled the `safety` job by setting `run_safety` to `false` and removed the `safety_options` configuration.
* [`.github/workflows/ci_tests.yml`](diffhunk://#diff-bf607a21ebbd18b3f436cc9fac6937d9c8839c33ae022cb29c2bddd873f470ebL71-R71): Changed the default values for `run_pylint` and `run_safety` to `false`. [[1]](diffhunk://#diff-bf607a21ebbd18b3f436cc9fac6937d9c8839c33ae022cb29c2bddd873f470ebL71-R71) [[2]](diffhunk://#diff-bf607a21ebbd18b3f436cc9fac6937d9c8839c33ae022cb29c2bddd873f470ebL92-R92)

### Documentation updates:

* [`docs/workflows/ci_tests.md`](diffhunk://#diff-dac04e2f09680363faa0b47df29d1dedf883d554cbcdd9bdc21c1a64fc32bfb9R49-R52): Added a deprecation notice for the `pylint` and `safety` jobs, recommending the use of `pre-commit` hooks and the `safety` GitHub Action.
* [`docs/workflows/ci_tests.md`](diffhunk://#diff-dac04e2f09680363faa0b47df29d1dedf883d554cbcdd9bdc21c1a64fc32bfb9L69-R74): Updated the default values for `run_pylint` and `run_safety` to `false` in the parameter table and marked related inputs as deprecated. [[1]](diffhunk://#diff-dac04e2f09680363faa0b47df29d1dedf883d554cbcdd9bdc21c1a64fc32bfb9L69-R74) [[2]](diffhunk://#diff-dac04e2f09680363faa0b47df29d1dedf883d554cbcdd9bdc21c1a64fc32bfb9L240-R252)