### PR TITLE
Fix GitHub env variables issue #234

### DIFF
--- a/.github/workflows/ci_cd_updated_default_branch.yml
+++ b/.github/workflows/ci_cd_updated_default_branch.yml
@@ -190,10 +190,12 @@ jobs:
         COMMIT_MSG="$(gh api /repos/${{ github.repository }}/commits/${{ inputs.default_repo_branch }} --jq '.commit.message')"
         if [[ "${COMMIT_MSG}" =~ ^Release\ v.*$ ]] || [ "${COMMIT_MSG}" == "[bot] Update documentation" ]; then
           echo "In a release or just ran this job - do not run this job !"
-          echo "release_run=true" >> $GITHUB_OUTPUT
+          RELEASE_RUN=true
+          echo "release_run=$RELEASE_RUN" >> $GITHUB_OUTPUT
         else
           echo "Not a release and did not just run this job - update docs"
-          echo "release_run=false" >> $GITHUB_OUTPUT
+          RELEASE_RUN=false
+          echo "release_run=$RELEASE_RUN" >> $GITHUB_OUTPUT
         fi
       env:
         GITHUB_TOKEN: ${{ secrets.PAT || secrets.GITHUB_TOKEN }}
@@ -368,7 +370,8 @@ jobs:
           fi
 
           git commit -m "[bot] Update documentation"
-          echo "UPDATE_DEFAULT_BRANCH=true" >> $GITHUB_ENV
+          UPDATE_DEFAULT_BRANCH=true
+          echo "UPDATE_DEFAULT_BRANCH=$UPDATE_DEFAULT_BRANCH" >> $GITHUB_ENV
         else
           echo -e "\u2714 All good !"
         fi
@@ -487,11 +490,13 @@ jobs:
 
           echo -e "### Update dependencies\n\nAutomatically created PR from [\`${{ inputs.permanent_dependencies_branch }}\`](https://github.com/${{ github.repository }}/tree/${{ inputs.permanent_dependencies_branch }}).\n\nThe PR is based on the ['CI - Update dependencies PR' workflow](https://SINTEF.github.io/ci-cd/latest/workflows/ci_update_dependencies/) in [SINTEF/ci-cd](https://github.com/SINTEF/ci-cd).\n\n#### To do\n" > ${PR_BODY_FILE}
           echo "Using default PR body (similar to the one used in the 'CI - Update dependencies PR' workflow)."
-          echo "remove_pr_body_file=true" >> $GITHUB_OUTPUT
+          REMOVE_PR_BODY_FILE=true
+          echo "remove_pr_body_file=$REMOVE_PR_BODY_FILE" >> $GITHUB_OUTPUT
         else
           echo "Using found PR body text file at ${{ inputs.update_dependencies_pr_body_file }}."
           echo "pr_body_file=${{ inputs.update_dependencies_pr_body_file }}" >> $GITHUB_OUTPUT
-          echo "remove_pr_body_file=false" >> $GITHUB_OUTPUT
+          REMOVE_PR_BODY_FILE=false
+          echo "remove_pr_body_file=$REMOVE_PR_BODY_FILE" >> $GITHUB_OUTPUT
         fi
 
     - name: Update '${{ inputs.permanent_dependencies_branch }}'
@@ -504,11 +509,13 @@ jobs:
         if [ -z "$(printf '%s\n' "${LATEST_PR_BODY}" | head -8 | diff - .tmp_file.txt --strip-trailing-cr)" ]; then
           echo "The dependencies have just been updated! Reset to ${{ inputs.default_repo_branch }}."
           git reset --hard origin/${{ inputs.default_repo_branch }}
-          echo "force_push=yes" >> $GITHUB_OUTPUT
+          FORCE_PUSH=yes
+          echo "force_push=$FORCE_PUSH" >> $GITHUB_OUTPUT
         else
           echo "Merge new updates to ${{ inputs.default_repo_branch }} into ${{ inputs.permanent_dependencies_branch }}"
           git merge -m "Keep '${{ inputs.permanent_dependencies_branch }}' up-to-date with '${{ inputs.default_repo_branch }}'" origin/${{ inputs.default_repo_branch }}
-          echo "force_push=no" >> $GITHUB_OUTPUT
+          FORCE_PUSH=no
+          echo "force_push=$FORCE_PUSH" >> $GITHUB_OUTPUT
         fi
 
         if [ "${{ steps.pr_body_config.outputs.remove_pr_body_file }}" == "true" ] && [ -f "${{ steps.pr_body_config.outputs.pr_body }}" ]; then

--- a/.github/workflows/ci_check_pyproject_dependencies.yml
+++ b/.github/workflows/ci_check_pyproject_dependencies.yml
@@ -116,7 +116,8 @@ jobs:
           # Cause of action: Set 'target_branch' to the (old) default value, and emit a deprecation warning.
 
           echo "::warning file=${{ github.workflow_ref }},title=Deprecation Warning::'permanent_dependencies_branch' is deprecated and will be removed in v2.6.0. Use 'target_branch' instead with explicit value. The old default value for 'permanent_dependencies_branch' was: 'ci/dependency-updates'."
-          echo "target_branch=ci/dependency-updates" >> $GITHUB_OUTPUT
+          TARGET_BRANCH=ci/dependency-updates
+          echo "target_branch=$TARGET_BRANCH" >> $GITHUB_OUTPUT
         elif [ -z "${{ inputs.target_branch }}" ] && [ -n "${{ inputs.permanent_dependencies_branch }}" ]; then
           # Scenario expected to be: One has set an explicit value for 'permanent_dependencies_branch' previously.
           # While not knowing that it is now deprecated, and one should instead use 'target_branch' with an explicitly set value.
@@ -231,11 +232,13 @@ jobs:
         fi
 
         if [ -n "$(git status --porcelain pyproject.toml)" ]; then
-          echo "update_dependencies=true" >> $GITHUB_OUTPUT
+          UPDATE_DEPENDENCIES=true
+          echo "update_dependencies=$UPDATE_DEPENDENCIES" >> $GITHUB_OUTPUT
           git add pyproject.toml
           git commit -m "Update dependencies in \`pyproject.toml\`"
         else
-          echo "update_dependencies=false" >> $GITHUB_OUTPUT
+          UPDATE_DEPENDENCIES=false
+          echo "update_dependencies=$UPDATE_DEPENDENCIES" >> $GITHUB_OUTPUT
         fi
 
     - name: Set PR body
@@ -252,11 +255,13 @@ jobs:
 
           echo -e "### Update dependencies (\`pyproject.toml\`)\n\nAutomatically created PR based on the ['CI - Check pyproject.toml dependencies' workflow](https://SINTEF.github.io/ci-cd/latest/workflows/ci_check_pyproject_dependencies/) in [SINTEF/ci-cd](https://github.com/SINTEF/ci-cd)." > ${PR_BODY_FILE}
           echo "Using default PR body."
-          echo "remove_pr_body_file=true" >> $GITHUB_OUTPUT
+          REMOVE_PR_BODY_FILE=true
+          echo "remove_pr_body_file=$REMOVE_PR_BODY_FILE" >> $GITHUB_OUTPUT
         else
           echo "Using found PR body text file at ${{ inputs.pr_body_file }}."
           echo "pr_body_file=${{ inputs.pr_body_file }}" >> $GITHUB_OUTPUT
-          echo "remove_pr_body_file=false" >> $GITHUB_OUTPUT
+          REMOVE_PR_BODY_FILE=false
+          echo "remove_pr_body_file=$REMOVE_PR_BODY_FILE" >> $GITHUB_OUTPUT
         fi
 
     - name: Fetch PR body

--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -442,11 +442,13 @@ jobs:
           ("${{ inputs.use_mkdocs }}" == "true" && "${{ inputs.use_sphinx }}" == "false") ]]; then
           # (Default to) using MkDocs
           echo "Framework determined: MkDocs"
-          echo "framework=mkdocs" >> $GITHUB_OUTPUT
+          FRAMEWORK=mkdocs
+          echo "framework=$FRAMEWORK" >> $GITHUB_OUTPUT
         elif [[ "${{ inputs.use_mkdocs }}" == "false" && "${{ inputs.use_sphinx }}" == "true" ]]; then
           # Use Sphinx
           echo "Framework determined: Sphinx"
-          echo "framework=sphinx" >> $GITHUB_OUTPUT
+          FRAMEWORK=sphinx
+          echo "framework=$FRAMEWORK" >> $GITHUB_OUTPUT
         else
           echo "Could not determine what documentation framework to use."
           echo "Note, the inputs 'use_mkdocs' and 'use_sphinx' are mutually exclusive."

--- a/.github/workflows/ci_update_dependencies.yml
+++ b/.github/workflows/ci_update_dependencies.yml
@@ -148,10 +148,12 @@ jobs:
         if [ -n "$(git status --porcelain .pre-commit-config.yaml)" ]; then
           # Set environment variable notifying next steps that the hooks changed
           echo "Pre-commit hooks have been updated !"
-          echo "updated_pre_commit_hooks=true" >> $GITHUB_OUTPUT
+          UPDATED_PRE_COMMIT_HOOKS=true
+          echo "updated_pre_commit_hooks=$UPDATED_PRE_COMMIT_HOOKS" >> $GITHUB_OUTPUT
         else
           echo "No pre-commit hooks have been updated."
-          echo "updated_pre_commit_hooks=false" >> $GITHUB_OUTPUT
+          UPDATED_PRE_COMMIT_HOOKS=false
+          echo "updated_pre_commit_hooks=$UPDATED_PRE_COMMIT_HOOKS" >> $GITHUB_OUTPUT
         fi
 
     - name: Possibly run `pre-commit` with updated hooks
@@ -179,11 +181,13 @@ jobs:
 
           echo -e "### Update dependencies\n\nAutomatically created PR from [\`${{ inputs.permanent_dependencies_branch }}\`](https://github.com/${{ github.repository }}/tree/${{ inputs.permanent_dependencies_branch }}).\n\nThe PR is based on the ['CI - Update dependencies PR' workflow](https://SINTEF.github.io/ci-cd/latest/workflows/ci_update_dependencies/) in [SINTEF/ci-cd](https://github.com/SINTEF/ci-cd).\n\n#### To do\n\n- [ ] Check that the diff is sensible, and that tests and builds pass with the new dependency versions.\n${{ inputs.extra_to_dos }}" > ${PR_BODY_FILE}
           echo "Using default PR body."
-          echo "remove_pr_body_file=true" >> $GITHUB_OUTPUT
+          REMOVE_PR_BODY_FILE=true
+          echo "remove_pr_body_file=$REMOVE_PR_BODY_FILE" >> $GITHUB_OUTPUT
         else
           echo "Using found PR body text file at ${{ inputs.pr_body_file }}."
           echo "pr_body_file=${{ inputs.pr_body_file }}" >> $GITHUB_OUTPUT
-          echo "remove_pr_body_file=false" >> $GITHUB_OUTPUT
+          REMOVE_PR_BODY_FILE=false
+          echo "remove_pr_body_file=$REMOVE_PR_BODY_FILE" >> $GITHUB_OUTPUT
         fi
 
     - name: Fetch PR body


### PR DESCRIPTION
- Define variables in bash style before passing to GITHUB_ENV/GITHUB_OUTPUT
- Changed 22 instances across 4 workflow files to improve readability
- Follows pattern: VAR=value; echo "VAR=$VAR" >> $GITHUB_OUTPUT

Files modified:
- .github/workflows/ci_cd_updated_default_branch.yml (7 lines)
- .github/workflows/ci_check_pyproject_dependencies.yml (5 lines)
- .github/workflows/ci_update_dependencies.yml (4 lines)
- .github/workflows/ci_tests.yml (2 lines)