### PR TITLE
Do not fail CI if codecov fails

### DIFF
--- a/.github/workflows/_local_ci_tests.yml
+++ b/.github/workflows/_local_ci_tests.yml
@@ -65,7 +65,7 @@ jobs:
       if: matrix.python-version == '3.9' && github.repository == 'SINTEF/ci-cd'
       uses: codecov/codecov-action@v6
       with:
-        fail_ci_if_error: true
+        fail_ci_if_error: false
         token: ${{ secrets.CODECOV_TOKEN }}
 
   # These jobs are mainly to test a default run of the hooks including `--pre-commit`


### PR DESCRIPTION
## AI Summary

This pull request makes a minor change to the CI workflow configuration. The change ensures that the CI job will not fail if the Codecov upload encounters an error, which can help prevent unrelated build failures.

- CI workflow configuration:
  * Changed the `fail_ci_if_error` option for the Codecov upload step in `.github/workflows/_local_ci_tests.yml` from `true` to `false`, so that errors in uploading coverage results will not cause the CI job to fail.